### PR TITLE
feat(admin): editable site content CMS

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,36 +1,34 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 
+import { fetchSiteContent } from "@/lib/content/query";
+
 export const metadata: Metadata = {
   title: "About",
   description: "About Brad Enns and real estate services in Kitchener–Waterloo.",
 };
 
-/**
- * Placeholder About page until final biography and media are added.
- *
- * @returns JSX for `/about`.
- */
+function digitsOnly(value: string) {
+  return value.replace(/\D/g, "");
+}
 
-export default function AboutPage() {
+export default async function AboutPage() {
+  const { payload: c } = await fetchSiteContent("about");
+  const phoneHref = `tel:${digitsOnly(c.phone)}`;
+  const emailHref = `mailto:${c.email}`;
+
   return (
     <div className="min-h-screen bg-white">
-      <div className="max-w-5xl mx-auto px-6 py-16 md:py-24">
-        {/* MOBILE ONLY: eyebrow + heading */}
+      <div className="mx-auto max-w-5xl px-6 py-16 md:py-24">
         <div className="md:hidden">
-          <p className="text-brand-gold text-base font-medium mb-2">
-            Kitchener, Waterloo Real Estate Agent
-          </p>
-          <h1 className="text-4xl font-medium text-slate-900 mb-5">Meet Brad Enns</h1>
+          <p className="mb-2 text-base font-medium text-brand-gold">{c.eyebrow}</p>
+          <h1 className="mb-5 text-4xl font-medium text-slate-900">{c.headline}</h1>
         </div>
 
-        <div className="flex flex-col md:flex-row gap-12 md:gap-16 items-start">
-          {/* LEFT COLUMN */}
-          <div className="w-full md:w-2/5 flex-shrink-0">
-            {/* PHOTO + MOBILE STAT CARDS side by side */}
-            <div className="flex gap-4 items-start">
-              {/* PHOTO */}
-              <div className="relative w-1/2 md:w-full aspect-[4/5] rounded-xl overflow-hidden flex-shrink-0">
+        <div className="flex flex-col items-start gap-12 md:flex-row md:gap-16">
+          <div className="w-full shrink-0 md:w-2/5">
+            <div className="flex items-start gap-4">
+              <div className="relative aspect-[4/5] w-1/2 shrink-0 overflow-hidden rounded-xl md:w-full">
                 <Image
                   src="/images/brad-enns.jpg"
                   alt="Brad Enns, Enns Real Estate"
@@ -40,89 +38,68 @@ export default function AboutPage() {
                 />
               </div>
 
-              {/* MOBILE ONLY: stat cards */}
-              <div className="md:hidden flex flex-col gap-4 flex-1">
-                <div className="bg-slate-100 rounded-xl p-4 text-center">
-                  <p className="text-3xl font-bold text-brand-gold">20+</p>
-                  <p className="text-sm text-slate-500 mt-1">homes sold</p>
+              <div className="flex flex-1 flex-col gap-4 md:hidden">
+                <div className="rounded-xl bg-slate-100 p-4 text-center">
+                  <p className="text-3xl font-bold text-brand-gold">{c.stat1Value}</p>
+                  <p className="mt-1 text-sm text-slate-500">{c.stat1Label}</p>
                 </div>
-                <div className="bg-slate-100 rounded-xl p-4 text-center">
-                  <p className="text-3xl font-bold text-brand-gold">5+</p>
-                  <p className="text-sm text-slate-500 mt-1">years of experience</p>
+                <div className="rounded-xl bg-slate-100 p-4 text-center">
+                  <p className="text-3xl font-bold text-brand-gold">{c.stat2Value}</p>
+                  <p className="mt-1 text-sm text-slate-500">{c.stat2Label}</p>
                 </div>
               </div>
             </div>
 
-            {/* CONTACT INFO */}
-            <div className="flex items-center gap-6 text-sm text-slate-600 mt-5">
+            <div className="mt-5 flex items-center gap-6 text-sm text-slate-600">
               <a
-                href="tel:5195001641"
-                className="flex items-center gap-2 hover:text-brand-gold transition-colors duration-200"
+                href={phoneHref}
+                className="flex items-center gap-2 transition-colors duration-200 hover:text-brand-gold"
               >
-                <Image src="/icons/Phone.svg" alt="" width={16} height={16} /> 519 - 500 - 1641
+                <Image src="/icons/Phone.svg" alt="" width={16} height={16} /> {c.phone}
               </a>
               <a
-                href="mailto:brad@mres.ca"
-                className="flex items-center gap-2 hover:text-brand-gold transition-colors duration-200"
+                href={emailHref}
+                className="flex items-center gap-2 transition-colors duration-200 hover:text-brand-gold"
               >
-                <Image src="/icons/Mail.svg" alt="" width={16} height={16} /> brad@mres.ca
+                <Image src="/icons/Mail.svg" alt="" width={16} height={16} /> {c.email}
               </a>
             </div>
 
-            {/* DESKTOP ONLY: Contact Brad Today button */}
             <a
               href="/contact"
-              className="hidden md:block mt-4 text-center border border-brand-gold text-brand-gold hover:bg-brand-gold hover:text-white font-semibold text-xs uppercase tracking-widest py-3.5 px-6 rounded transition-colors duration-200"
+              className="mt-4 hidden rounded border border-brand-gold px-6 py-3.5 text-center text-xs font-semibold uppercase tracking-widest text-brand-gold transition-colors duration-200 hover:bg-brand-gold hover:text-white md:block"
             >
-              Contact Brad Today
+              {c.ctaLabel}
             </a>
           </div>
 
-          {/* RIGHT COLUMN */}
           <div className="w-full md:w-3/5">
-            {/* DESKTOP ONLY: eyebrow + heading */}
             <div className="hidden md:block">
-              <p className="text-brand-gold text-base font-medium mb-2">
-                Kitchener, Waterloo Real Estate Agent
-              </p>
-              <h1 className="text-4xl md:text-5xl font-medium text-slate-900 mb-5">
-                Meet Brad Enns
-              </h1>
+              <p className="mb-2 text-base font-medium text-brand-gold">{c.eyebrow}</p>
+              <h1 className="mb-5 text-4xl font-medium text-slate-900 md:text-5xl">{c.headline}</h1>
             </div>
 
-            {/* BIO PARAGRAPH */}
-            <p className="text-slate-600 leading-relaxed mb-6">
-              Description descriptions Description descriptions descriptions descriptions
-              descriptions descriptions descriptions descriptions descriptions
-              descriptionsdescriptionsdescriptionsdescriptions.
-            </p>
+            <p className="mb-6 leading-relaxed text-slate-600">{c.bio}</p>
 
-            {/* SUBHEADING + SECOND PARAGRAPH */}
-            <h2 className="text-lg font-bold text-slate-900 mb-3">Another heading / What I do</h2>
-            <p className="text-slate-600 leading-relaxed mb-8">
-              appraisal details appraisal details appraisal details appraisal details appraisal
-              details appraisal details appraisal details appraisal details appraisal details
-              appraisal details
-            </p>
+            <h2 className="mb-3 text-lg font-bold text-slate-900">{c.subheading}</h2>
+            <p className="mb-8 leading-relaxed text-slate-600">{c.subBio}</p>
 
-            {/* DESKTOP ONLY: stat cards */}
-            <div className="hidden md:grid grid-cols-2 gap-4">
-              <div className="bg-slate-100 rounded-xl p-6 text-center">
-                <p className="text-4xl font-bold text-brand-gold">20+</p>
-                <p className="text-sm text-slate-500 mt-1">homes sold</p>
+            <div className="hidden grid-cols-2 gap-4 md:grid">
+              <div className="rounded-xl bg-slate-100 p-6 text-center">
+                <p className="text-4xl font-bold text-brand-gold">{c.stat1Value}</p>
+                <p className="mt-1 text-sm text-slate-500">{c.stat1Label}</p>
               </div>
-              <div className="bg-slate-100 rounded-xl p-6 text-center">
-                <p className="text-4xl font-bold text-brand-gold">5+</p>
-                <p className="text-sm text-slate-500 mt-1">years of experience</p>
+              <div className="rounded-xl bg-slate-100 p-6 text-center">
+                <p className="text-4xl font-bold text-brand-gold">{c.stat2Value}</p>
+                <p className="mt-1 text-sm text-slate-500">{c.stat2Label}</p>
               </div>
             </div>
 
-            {/* MOBILE ONLY: Contact Brad Today button */}
             <a
               href="/contact"
-              className="md:hidden mt-6 block text-center border border-brand-gold text-brand-gold hover:bg-brand-gold hover:text-white font-semibold text-xs uppercase tracking-widest py-3.5 px-6 rounded transition-colors duration-200"
+              className="mt-6 block rounded border border-brand-gold px-6 py-3.5 text-center text-xs font-semibold uppercase tracking-widest text-brand-gold transition-colors duration-200 hover:bg-brand-gold hover:text-white md:hidden"
             >
-              Contact Brad Today
+              {c.ctaLabel}
             </a>
           </div>
         </div>
@@ -130,3 +107,4 @@ export default function AboutPage() {
     </div>
   );
 }
+

--- a/src/app/admin/(dashboard)/content/[key]/page.tsx
+++ b/src/app/admin/(dashboard)/content/[key]/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { SiteContentEditor } from "@/components/admin/site-content-editor";
+import { isSiteContentKey } from "@/lib/content/keys";
+import { SITE_CONTENT_PAGES } from "@/lib/content/keys";
+import { fetchSiteContent } from "@/lib/content/query";
+
+type Params = { params: Promise<{ key: string }> };
+
+export async function generateMetadata(ctx: Params): Promise<Metadata> {
+  const { key } = await ctx.params;
+  const page = SITE_CONTENT_PAGES.find((p) => p.key === key);
+  return {
+    title: page ? `Edit ${page.label}` : "Edit content",
+    description: "Edit marketing page copy.",
+  };
+}
+
+export default async function AdminContentEditPage(ctx: Params) {
+  const { key } = await ctx.params;
+  if (!isSiteContentKey(key)) {
+    notFound();
+  }
+
+  const row = await fetchSiteContent(key);
+
+  return (
+    <div className="min-h-[calc(100vh-4rem)] bg-slate-50 py-10">
+      <div className="mx-auto max-w-2xl px-4 sm:px-6">
+        <SiteContentEditor
+          pageKey={key}
+          initialPayload={row.payload}
+          updatedAt={row.updatedAt}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(dashboard)/content/page.tsx
+++ b/src/app/admin/(dashboard)/content/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { SITE_CONTENT_PAGES } from "@/lib/content/keys";
+
+export const metadata: Metadata = {
+  title: "Site content",
+  description: "Edit marketing page copy.",
+};
+
+export default function AdminContentHubPage() {
+  return (
+    <div className="min-h-[calc(100vh-4rem)] bg-slate-50 py-10">
+      <div className="mx-auto max-w-3xl space-y-6 px-4 sm:px-6">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight text-zinc-900">Site content</h1>
+          <p className="mt-2 text-sm text-zinc-600">
+            Edit text on the main marketing pages. Changes appear on the live site without a redeploy.
+          </p>
+        </div>
+
+        <ul className="space-y-3">
+          {SITE_CONTENT_PAGES.map((page) => (
+            <li key={page.key}>
+              <Link
+                href={`/admin/content/${page.key}`}
+                className="block rounded-lg border border-zinc-200 bg-white px-5 py-4 shadow-sm transition-colors hover:border-[#4a6d95]/40 hover:bg-zinc-50"
+              >
+                <p className="font-medium text-[#140000]">{page.label}</p>
+                <p className="mt-1 text-sm text-zinc-600">{page.description}</p>
+                <p className="mt-2 text-xs text-zinc-500">Public: {page.publicPath}</p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+
+        <p className="text-sm text-zinc-500">
+          Listing photos and pricing are managed under{" "}
+          <Link href="/admin/listings" className="font-medium text-[#4a6d95] hover:underline">
+            Listings
+          </Link>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/content/[key]/route.ts
+++ b/src/app/api/admin/content/[key]/route.ts
@@ -1,0 +1,67 @@
+import { jsonError, jsonOk } from "@/lib/api/http";
+import { requireAdmin } from "@/lib/auth/admin";
+import { upsertSiteContent } from "@/lib/content/admin";
+import { isSiteContentKey } from "@/lib/content/keys";
+import { fetchSiteContent } from "@/lib/content/query";
+import { siteContentSchemas } from "@/lib/validations/site-content";
+
+type Params = { params: Promise<{ key: string }> };
+
+/**
+ * `GET /api/admin/content/[key]` — Load editable page copy for admin forms.
+ */
+export async function GET(request: Request, ctx: Params) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) {
+    return jsonError(auth.message, auth.status, "UNAUTHORIZED");
+  }
+
+  const { key } = await ctx.params;
+  if (!isSiteContentKey(key)) {
+    return jsonError("Unknown content page", 404, "NOT_FOUND");
+  }
+
+  try {
+    const row = await fetchSiteContent(key);
+    return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Failed to load content";
+    return jsonError(message, 500, "CONTENT_ERROR");
+  }
+}
+
+/**
+ * `PUT /api/admin/content/[key]` — Save page copy (admin bearer token required).
+ */
+export async function PUT(request: Request, ctx: Params) {
+  const auth = await requireAdmin(request);
+  if (!auth.ok) {
+    return jsonError(auth.message, auth.status, "UNAUTHORIZED");
+  }
+
+  const { key } = await ctx.params;
+  if (!isSiteContentKey(key)) {
+    return jsonError("Unknown content page", 404, "NOT_FOUND");
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError("Invalid JSON body", 400, "BAD_REQUEST");
+  }
+
+  const schema = siteContentSchemas[key];
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return jsonError("Validation failed", 400, "VALIDATION_ERROR", parsed.error.flatten());
+  }
+
+  try {
+    const row = await upsertSiteContent(key, parsed.data);
+    return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Failed to save content";
+    return jsonError(message, 500, "CONTENT_ERROR");
+  }
+}

--- a/src/app/api/content/[key]/route.ts
+++ b/src/app/api/content/[key]/route.ts
@@ -1,0 +1,23 @@
+import { jsonError, jsonOk } from "@/lib/api/http";
+import { isSiteContentKey } from "@/lib/content/keys";
+import { fetchSiteContent } from "@/lib/content/query";
+
+type Params = { params: Promise<{ key: string }> };
+
+/**
+ * `GET /api/content/[key]` — Public JSON for a marketing page content blob.
+ */
+export async function GET(_request: Request, ctx: Params) {
+  const { key } = await ctx.params;
+  if (!isSiteContentKey(key)) {
+    return jsonError("Content not found", 404, "NOT_FOUND");
+  }
+
+  try {
+    const row = await fetchSiteContent(key);
+    return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Failed to load content";
+    return jsonError(message, 500, "CONTENT_ERROR");
+  }
+}

--- a/src/app/api/content/about/route.ts
+++ b/src/app/api/content/about/route.ts
@@ -1,16 +1,8 @@
-import { jsonError, jsonOk } from "@/lib/api/http";
-import { getSiteContent } from "@/lib/store/memory";
+import { jsonOk } from "@/lib/api/http";
+import { fetchSiteContent } from "@/lib/content/query";
 
-/**
- * `GET /api/content/about` — JSON payload for the About page.
- *
- * @returns JSON `{ data: { content, updatedAt } }`, or 404 if missing.
- */
+/** `GET /api/content/about` — JSON payload for the About page. */
 export async function GET() {
-  const row = getSiteContent("about");
-  if (!row) {
-    return jsonError("About content not found", 404, "NOT_FOUND");
-  }
-
-  return jsonOk({ content: row.payload, updatedAt: row.updated_at });
+  const row = await fetchSiteContent("about");
+  return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
 }

--- a/src/app/api/content/homepage/route.ts
+++ b/src/app/api/content/homepage/route.ts
@@ -1,16 +1,8 @@
-import { jsonError, jsonOk } from "@/lib/api/http";
-import { getSiteContent } from "@/lib/store/memory";
+import { jsonOk } from "@/lib/api/http";
+import { fetchSiteContent } from "@/lib/content/query";
 
-/**
- * `GET /api/content/homepage` — JSON payload for homepage CMS-style content.
- *
- * @returns JSON `{ data: { content, updatedAt } }`, or 404 if missing.
- */
+/** `GET /api/content/homepage` — JSON payload for homepage CMS-style content. */
 export async function GET() {
-  const row = getSiteContent("homepage");
-  if (!row) {
-    return jsonError("Homepage content not found", 404, "NOT_FOUND");
-  }
-
-  return jsonOk({ content: row.payload, updatedAt: row.updated_at });
+  const row = await fetchSiteContent("homepage");
+  return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,25 +1,25 @@
 import type { Metadata } from "next";
+
 import { ContactForm } from "@/components/contact/contact-form";
+import { fetchSiteContent } from "@/lib/content/query";
 
 export const metadata: Metadata = {
   title: "Contact",
   description: "Get in touch with Brad Enns.",
 };
 
-/**
- * Public `/contact` page. Composes the page-level layout (heading, intro,
- * and contact info) around the `ContactForm` component.
- *
- * @returns JSX for `/contact`.
- */
-export default function ContactPage() {
+function digitsOnly(value: string) {
+  return value.replace(/\D/g, "");
+}
+
+export default async function ContactPage() {
+  const { payload: c } = await fetchSiteContent("contact");
+
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
       <header className="text-center">
-        <h1 className="text-4xl font-semibold tracking-tight text-zinc-900">Get in Touch</h1>
-        <p className="mx-auto mt-4 max-w-xl leading-relaxed text-zinc-600">
-          Ready to buy, sell, or have questions about the market? Send a message or give me a call.
-        </p>
+        <h1 className="text-4xl font-semibold tracking-tight text-zinc-900">{c.title}</h1>
+        <p className="mx-auto mt-4 max-w-xl leading-relaxed text-zinc-600">{c.intro}</p>
       </header>
 
       <div className="mt-12">
@@ -28,52 +28,58 @@ export default function ContactPage() {
 
       <section className="mt-16">
         <h2 className="text-center text-lg font-semibold tracking-tight text-zinc-900">
-          Other ways to reach me
+          {c.sectionTitle}
         </h2>
 
         <dl className="mx-auto mt-6 grid max-w-md grid-cols-[6rem_1fr] gap-x-6 gap-y-3 text-zinc-900">
           <dt className="font-semibold text-zinc-700">Mobile</dt>
           <dd>
-            <a href="tel:5195001641" className="hover:text-zinc-600 hover:underline">
-              (519) 500-1641
+            <a
+              href={`tel:${digitsOnly(c.mobile)}`}
+              className="hover:text-zinc-600 hover:underline"
+            >
+              {c.mobile}
             </a>
           </dd>
 
           <dt className="font-semibold text-zinc-700">Office</dt>
           <dd>
-            <a href="tel:5198887778" className="hover:text-zinc-600 hover:underline">
-              (519) 888-7778
+            <a
+              href={`tel:${digitsOnly(c.office)}`}
+              className="hover:text-zinc-600 hover:underline"
+            >
+              {c.office}
             </a>
           </dd>
 
           <dt className="font-semibold text-zinc-700">Fax</dt>
-          <dd>(519) 954-7575</dd>
+          <dd>{c.fax}</dd>
 
           <dt className="font-semibold text-zinc-700">Email</dt>
           <dd>
-            <a href="mailto:brad@mres.ca" className="hover:text-zinc-600 hover:underline">
-              brad@mres.ca
+            <a href={`mailto:${c.email}`} className="hover:text-zinc-600 hover:underline">
+              {c.email}
             </a>
           </dd>
 
           <dt className="font-semibold text-zinc-700">Address</dt>
           <dd>
             <a
-              href="https://maps.google.com/?q=368+Ash+Tree+Place+Waterloo+ON+N2T+1R7"
+              href={`https://maps.google.com/?q=${encodeURIComponent(`${c.addressLine1} ${c.addressLine2}`)}`}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-zinc-600 hover:underline"
             >
-              368 Ash Tree Place
+              {c.addressLine1}
               <br />
-              Waterloo, ON N2T 1R7
+              {c.addressLine2}
             </a>
           </dd>
 
           <dt className="font-semibold text-zinc-700">Socials</dt>
           <dd className="flex items-center gap-3">
             <a
-              href="https://www.facebook.com/ennsrealestate"
+              href={c.facebookUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-zinc-600 hover:underline"
@@ -83,9 +89,8 @@ export default function ContactPage() {
             <span aria-hidden="true" className="text-zinc-400">
               ·
             </span>
-
             <a
-              href="https://ca.linkedin.com/pub/brad-enns/44/75b/5b9"
+              href={c.linkedinUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-zinc-600 hover:underline"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SiteChrome } from "@/components/site-chrome";
+import { SiteFooter } from "@/components/site-footer";
 import "./globals.css";
 
 /** Sans body font via `next/font`; exposes `--font-geist-sans` on the document root. */
@@ -31,7 +32,7 @@ export const metadata: Metadata = {
  * @param children - Page segment content (e.g. home, about).
  * @returns HTML document shell with header and `<main>`.
  */
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
@@ -39,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="flex min-h-full flex-col">
-        <SiteChrome>{children}</SiteChrome>
+        <SiteChrome footer={<SiteFooter />}>{children}</SiteChrome>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,15 @@
 import { HomeHero } from "@/components/home/home-hero";
+import { fetchSiteContent } from "@/lib/content/query";
 
-export default function HomePage() {
-  return <HomeHero />;
+export default async function HomePage() {
+  const { payload } = await fetchSiteContent("homepage");
+
+  return (
+    <HomeHero
+      heroEyebrow={payload.heroEyebrow}
+      heroTitle={payload.heroTitle}
+      heroDescription={payload.heroDescription}
+      heroCtaLabel={payload.heroCtaLabel}
+    />
+  );
 }

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { Montserrat, Poppins } from "next/font/google";
 
+import { fetchSiteContent } from "@/lib/content/query";
+
 const poppins = Poppins({
   weight: ["400", "500"],
   subsets: ["latin"],
@@ -12,71 +14,62 @@ const montserrat = Montserrat({
   subsets: ["latin"],
 });
 
-const placeholderBody =
-  "Appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details.";
-
-const serviceCards = [
-  {
-    title: "Home Appraisal",
-    iconSrc: "/icons/appraisal.svg",
-    iconWidth: 116,
-    iconHeight: 99,
-    body: placeholderBody,
-  },
-  {
-    title: "Buying",
-    iconSrc: "/icons/buying.svg",
-    iconWidth: 111,
-    iconHeight: 99,
-    body: placeholderBody,
-  },
-  {
-    title: "Selling",
-    iconSrc: "/icons/selling.svg",
-    iconWidth: 95,
-    iconHeight: 90,
-    body: placeholderBody,
-  },
-] as const;
-
 export const metadata: Metadata = {
   title: "Services",
   description: "Enns Real Estate services in Kitchener–Waterloo and surrounding communities.",
 };
 
-/**
- * Services overview: hero copy and three service cards (appraisal, buying, selling).
- *
- * @returns JSX for `/services`.
- */
-export default function ServicesPage() {
+export default async function ServicesPage() {
+  const { payload: c } = await fetchSiteContent("services");
+
+  const serviceCards = [
+    {
+      title: c.appraisalTitle,
+      iconSrc: "/icons/appraisal.svg",
+      iconWidth: 116,
+      iconHeight: 99,
+      body: c.appraisalBody,
+    },
+    {
+      title: c.buyingTitle,
+      iconSrc: "/icons/buying.svg",
+      iconWidth: 111,
+      iconHeight: 99,
+      body: c.buyingBody,
+    },
+    {
+      title: c.sellingTitle,
+      iconSrc: "/icons/selling.svg",
+      iconWidth: 95,
+      iconHeight: 90,
+      body: c.sellingBody,
+    },
+  ] as const;
+
   return (
     <div className="w-full">
-      {/* MOBILE ONLY: hero */}
       <div className="mx-auto w-full max-w-3xl px-4 pb-3 pt-12 sm:px-6 sm:pb-4 md:hidden">
         <h1 className="text-center text-4xl font-medium text-slate-900 dark:text-zinc-50">
-          Enns Real Estate Services
+          {c.heroTitle}
         </h1>
         <p
           className={`${poppins.className} mt-6 text-center text-[20px] font-normal leading-normal text-[#7b7b7b]`}
         >
-          We’re here to help you value, buy, and sell your home.
+          {c.heroDescription}
         </p>
       </div>
 
-      {/* DESKTOP ONLY: hero */}
       <div className="mx-auto hidden w-full max-w-3xl px-4 pb-3 pt-12 sm:px-6 sm:pb-4 md:block">
         <h1 className="text-center text-4xl font-medium text-slate-900 dark:text-zinc-50 md:text-5xl">
-          Enns Real Estate Services
+          {c.heroTitle}
         </h1>
         <p
           className={`${poppins.className} mt-6 text-center text-[20px] font-normal leading-normal text-[#7b7b7b]`}
         >
-          We’re here to help you value, buy, and sell your home.
+          {c.heroDescription}
         </p>
       </div>
 
-      {/* Service cards (single column on mobile, three columns from md) */}
       <section
         className="bg-white pb-10 pt-5 dark:bg-zinc-950 sm:pb-14 sm:pt-6"
         aria-label="Service offerings"

--- a/src/components/admin/admin-dashboard-overview.tsx
+++ b/src/components/admin/admin-dashboard-overview.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { DashboardLead, ListingStatusCounts } from "@/lib/admin/dashboard-data";
+import { Button } from "@/components/ui/button";
 
 type AdminDashboardOverviewProps = {
   counts: ListingStatusCounts;
@@ -45,19 +46,19 @@ export function AdminDashboardOverview({ counts, leads }: AdminDashboardOverview
           ))}
         </div>
         <p className="mt-3 text-sm text-zinc-500">
-          {counts.total} listing{counts.total === 1 ? "" : "s"} total.{" "}
-          <Link href="/listings" className="font-medium text-[#4a6d95] hover:underline">
-            View public listings
-          </Link>
-          {" · "}
-          <Link href="/admin/listings" className="font-medium text-[#4a6d95] hover:underline">
-            Manage listings
-          </Link>
-          {" · "}
-          <Link href="/admin/content" className="font-medium text-[#4a6d95] hover:underline">
-            Edit site content
-          </Link>
+          {counts.total} listing{counts.total === 1 ? "" : "s"} total.
         </p>
+        <div className="mt-4 flex w-full gap-2 sm:gap-3">
+          <Button variant="outline" className="h-11 min-h-11 flex-1 basis-0 px-2 text-center text-sm" asChild>
+            <Link href="/listings">View public listings</Link>
+          </Button>
+          <Button className="h-11 min-h-11 flex-1 basis-0 px-2 text-center text-sm" asChild>
+            <Link href="/admin/listings">Manage listings</Link>
+          </Button>
+          <Button variant="outline" className="h-11 min-h-11 flex-1 basis-0 px-2 text-center text-sm" asChild>
+            <Link href="/admin/content">Edit site content</Link>
+          </Button>
+        </div>
       </section>
 
       <section className="rounded-xl border border-zinc-200 bg-white shadow-sm">

--- a/src/components/admin/admin-dashboard-overview.tsx
+++ b/src/components/admin/admin-dashboard-overview.tsx
@@ -53,6 +53,10 @@ export function AdminDashboardOverview({ counts, leads }: AdminDashboardOverview
           <Link href="/admin/listings" className="font-medium text-[#4a6d95] hover:underline">
             Manage listings
           </Link>
+          {" · "}
+          <Link href="/admin/content" className="font-medium text-[#4a6d95] hover:underline">
+            Edit site content
+          </Link>
         </p>
       </section>
 

--- a/src/components/admin/site-content-editor.tsx
+++ b/src/components/admin/site-content-editor.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { SITE_CONTENT_PAGES } from "@/lib/content/keys";
+import { SITE_CONTENT_EDITOR_FIELDS } from "@/lib/content/editor-fields";
+import type { SiteContentKey } from "@/lib/content/keys";
+import type { SiteContentPayload } from "@/lib/content/types";
+import { useAdminUser } from "@/hooks/use-admin-user";
+import { isSupabaseBrowserConfigured } from "@/lib/supabase/public-config";
+
+type SiteContentEditorProps = {
+  pageKey: SiteContentKey;
+  initialPayload: SiteContentPayload<SiteContentKey>;
+  updatedAt: string | null;
+};
+
+function payloadToFormState(payload: SiteContentPayload<SiteContentKey>) {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    out[key] = typeof value === "string" ? value : "";
+  }
+  return out;
+}
+
+export function SiteContentEditor({ pageKey, initialPayload, updatedAt }: SiteContentEditorProps) {
+  const router = useRouter();
+  const { accessToken } = useAdminUser();
+  const page = SITE_CONTENT_PAGES.find((p) => p.key === pageKey);
+  const fields = SITE_CONTENT_EDITOR_FIELDS[pageKey];
+
+  const [form, setForm] = useState(() => payloadToFormState(initialPayload));
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState("");
+
+  function setField(name: string, value: string) {
+    setForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (isSupabaseBrowserConfigured() && !accessToken) {
+      setMessage("You must sign in as an admin before saving changes.");
+      return;
+    }
+
+    setBusy(true);
+    setMessage("");
+    try {
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      if (accessToken) {
+        headers.Authorization = `Bearer ${accessToken}`;
+      }
+
+      const res = await fetch(`/api/admin/content/${pageKey}`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data?.error?.message ?? "Could not save content.");
+      }
+      setMessage("Saved. Refresh the public page to confirm.");
+      router.refresh();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : "Could not save content.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="space-y-6 rounded-lg border border-slate-300 bg-white p-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm text-zinc-500">
+            <Link href="/admin/content" className="text-[#4a6d95] hover:underline">
+              Site content
+            </Link>
+            {" / "}
+            {page?.label ?? pageKey}
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold text-[#140000]">{page?.label ?? pageKey}</h1>
+          {page?.description ? <p className="mt-2 text-sm text-zinc-600">{page.description}</p> : null}
+        </div>
+        {page?.publicPath ? (
+          <Link
+            href={page.publicPath}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-700 hover:bg-zinc-50"
+          >
+            View public page
+          </Link>
+        ) : null}
+      </div>
+
+      {updatedAt ? (
+        <p className="text-xs text-zinc-500">
+          Last saved: {new Date(updatedAt).toLocaleString()}
+        </p>
+      ) : null}
+
+      <form className="space-y-4" onSubmit={(e) => void onSave(e)}>
+        {fields.map((field) => (
+          <label key={field.name} className="block space-y-1">
+            <span className="text-sm font-medium text-zinc-800">{field.label}</span>
+            {field.multiline ? (
+              <textarea
+                value={form[field.name] ?? ""}
+                onChange={(e) => setField(field.name, e.target.value)}
+                rows={4}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900"
+              />
+            ) : (
+              <input
+                type="text"
+                value={form[field.name] ?? ""}
+                onChange={(e) => setField(field.name, e.target.value)}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900"
+              />
+            )}
+          </label>
+        ))}
+
+        {message ? (
+          <p className={`text-sm ${message.startsWith("Saved") ? "text-emerald-700" : "text-red-600"}`}>
+            {message}
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-md bg-[#4a6d95] px-5 py-2.5 text-sm font-medium text-white hover:bg-[#3f5f84] disabled:opacity-50"
+          >
+            {busy ? "Saving…" : "Save changes"}
+          </button>
+          <Link
+            href="/admin/content"
+            className="rounded-md border border-zinc-300 px-5 py-2.5 text-sm font-medium text-zinc-800 hover:bg-zinc-50"
+          >
+            Back
+          </Link>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/src/components/home/home-hero.tsx
+++ b/src/components/home/home-hero.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { Poppins } from "next/font/google";
 
+import type { HomepageContent } from "@/lib/content/types";
+
 const poppins = Poppins({
   subsets: ["latin"],
   weight: ["400", "500", "600"],
@@ -9,7 +11,12 @@ const poppins = Poppins({
 
 const HERO_IMAGE = "/images/homepage_background_temp.jpg";
 
-export function HomeHero() {
+type HomeHeroProps = Pick<
+  HomepageContent,
+  "heroEyebrow" | "heroTitle" | "heroDescription" | "heroCtaLabel"
+>;
+
+export function HomeHero({ heroEyebrow, heroTitle, heroDescription, heroCtaLabel }: HomeHeroProps) {
   return (
     <section className="relative min-h-[calc(100vh-4rem)] w-full overflow-hidden">
       <Image
@@ -26,19 +33,18 @@ export function HomeHero() {
         className={`absolute bottom-0 left-0 z-10 pb-12 pl-5 sm:pb-16 sm:pl-8 md:pb-20 md:pl-10 lg:pl-14 ${poppins.className}`}
       >
         <div className="max-w-xl text-white">
-          <p className="text-base font-normal sm:text-lg">Kitchener, Waterloo</p>
+          <p className="text-base font-normal sm:text-lg">{heroEyebrow}</p>
           <h1 className="mt-2 text-4xl font-semibold leading-tight tracking-tight sm:text-5xl md:text-[3.25rem]">
-            Enns Real Estate
+            {heroTitle}
           </h1>
           <p className="mt-5 max-w-lg text-sm leading-relaxed text-white/95 sm:text-base">
-            Real estate and brief agent description. Real estate and brief agent description. Real
-            estate and brief agent description.
+            {heroDescription}
           </p>
           <Link
             href="/about"
             className="mt-8 inline-flex items-center justify-center rounded-md bg-[#4a6d95] px-8 py-3 text-xs font-medium uppercase tracking-wider text-white transition-colors hover:bg-[#3f5f84] sm:text-sm"
           >
-            LEARN MORE
+            {heroCtaLabel}
           </Link>
         </div>
       </div>

--- a/src/components/site-chrome.tsx
+++ b/src/components/site-chrome.tsx
@@ -3,7 +3,6 @@
 import { usePathname } from "next/navigation";
 
 import { AuthLandingRedirect } from "@/components/auth/auth-landing-redirect";
-import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 
 /** Admin sign-in / sign-up / password recovery: no marketing footer. */
@@ -20,7 +19,13 @@ function isAdminAuthChromePath(pathname: string): boolean {
   return false;
 }
 
-export function SiteChrome({ children }: { children: React.ReactNode }) {
+export function SiteChrome({
+  children,
+  footer,
+}: {
+  children: React.ReactNode;
+  footer: React.ReactNode;
+}) {
   const pathname = usePathname();
   const hideFooter = isAdminAuthChromePath(pathname);
 
@@ -29,7 +34,7 @@ export function SiteChrome({ children }: { children: React.ReactNode }) {
       <AuthLandingRedirect />
       <SiteHeader />
       <main className="flex-1">{children}</main>
-      {!hideFooter ? <SiteFooter /> : null}
+      {!hideFooter ? footer : null}
     </>
   );
 }

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+import { fetchSiteContent } from "@/lib/content/query";
+
+export async function SiteFooter() {
+  const { payload } = await fetchSiteContent("footer");
+
+  return (
+    <footer className="mt-auto border-t border-zinc-200 bg-zinc-50">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <p className="text-sm text-zinc-600">
+          © {new Date().getFullYear()} {payload.copyright}
+        </p>
+        <div className="flex flex-wrap gap-4 text-sm">
+          <Link href="/contact" className="text-zinc-600 hover:text-zinc-900">
+            Contact
+          </Link>
+          <a
+            href={payload.facebookUrl}
+            className="text-zinc-600 hover:text-zinc-900"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Facebook
+          </a>
+          <a
+            href={payload.linkedinUrl}
+            className="text-zinc-600 hover:text-zinc-900"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            LinkedIn
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/site-header-nav.tsx
+++ b/src/components/site-header-nav.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 
 import { useAdminUser } from "@/hooks/use-admin-user";
 
-const nav = [
+export const siteHeaderNavItems = [
   { href: "/", label: "Home" },
   { href: "/about", label: "About" },
   { href: "/services", label: "Services" },
@@ -23,7 +23,7 @@ export function SiteHeaderNav({ className, linkClassName }: SiteHeaderNavProps) 
 
   return (
     <nav className={className} style={{ columnGap: "2.5rem" }} aria-label="Main">
-      {nav.map((item, index) => (
+      {siteHeaderNavItems.map((item, index) => (
         <Link
           key={item.href}
           href={item.href}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Poppins } from "next/font/google";
 
 import { SiteHeaderCta } from "@/components/site-header-cta";
-import { SiteHeaderNav } from "@/components/site-header-nav";
+import { SiteHeaderNav, siteHeaderNavItems } from "@/components/site-header-nav";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -40,7 +40,7 @@ export function SiteHeader() {
         className={`flex items-center justify-center gap-6 overflow-x-auto border-t border-zinc-100 px-4 py-2 sm:hidden ${poppins.className}`}
         aria-label="Main mobile"
       >
-        {nav.map((item) => (
+        {siteHeaderNavItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}

--- a/src/lib/content/admin.ts
+++ b/src/lib/content/admin.ts
@@ -1,0 +1,44 @@
+import type { SiteContentKey } from "@/lib/content/keys";
+import type { SiteContentPayload } from "@/lib/content/types";
+import { upsertSiteContent as upsertSiteContentMemory } from "@/lib/store/memory";
+import { getSupabaseAdminClient, hasSupabaseAdminConfig } from "@/lib/supabase/server";
+
+export async function upsertSiteContent<K extends SiteContentKey>(
+  key: K,
+  payload: SiteContentPayload<K>,
+) {
+  const updatedAt = new Date().toISOString();
+
+  if (!hasSupabaseAdminConfig()) {
+    const row = upsertSiteContentMemory(key, payload);
+    return {
+      pageKey: key,
+      payload: row.payload as SiteContentPayload<K>,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from("site_content")
+    .upsert(
+      {
+        page_key: key,
+        payload,
+        updated_at: updatedAt,
+      },
+      { onConflict: "page_key" },
+    )
+    .select("page_key,payload,updated_at")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return {
+    pageKey: key,
+    payload: data.payload as SiteContentPayload<K>,
+    updatedAt: data.updated_at as string,
+  };
+}

--- a/src/lib/content/defaults.ts
+++ b/src/lib/content/defaults.ts
@@ -1,0 +1,73 @@
+import type { SiteContentKey } from "@/lib/content/keys";
+import type { SiteContentPayload, SiteContentPayloadMap } from "@/lib/content/types";
+
+const DEFAULTS: SiteContentPayloadMap = {
+  homepage: {
+    heroEyebrow: "Kitchener, Waterloo",
+    heroTitle: "Enns Real Estate",
+    heroDescription:
+      "Real estate and brief agent description. Real estate and brief agent description. Real estate and brief agent description.",
+    heroCtaLabel: "LEARN MORE",
+    primaryCtaLabel: "View listings",
+    secondaryCtaLabel: "Contact Brad",
+    sectionTitle: "How I can help",
+    buyingTitle: "Buying",
+    buyingText: "Strategy for homes that fit your budget, neighbourhood, and timeline.",
+    sellingTitle: "Selling",
+    sellingText: "Pricing context, presentation, and negotiation with less guesswork.",
+    appraisalsTitle: "Appraisals",
+    appraisalsText: "Context on value and what to expect when numbers land on paper.",
+    footerNote: "Placeholder copy. Replace with Brad's voice, neighbourhoods, and credentials.",
+  },
+  about: {
+    eyebrow: "Kitchener, Waterloo Real Estate Agent",
+    headline: "Meet Brad Enns",
+    bio: "Description descriptions Description descriptions descriptions descriptions descriptions descriptions descriptions descriptions descriptions descriptionsdescriptionsdescriptionsdescriptions.",
+    subheading: "Another heading / What I do",
+    subBio:
+      "appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details",
+    stat1Value: "20+",
+    stat1Label: "homes sold",
+    stat2Value: "5+",
+    stat2Label: "years of experience",
+    phone: "519 - 500 - 1641",
+    email: "brad@mres.ca",
+    ctaLabel: "Contact Brad Today",
+  },
+  services: {
+    heroTitle: "Enns Real Estate Services",
+    heroDescription: "We're here to help you value, buy, and sell your home.",
+    appraisalTitle: "Home Appraisal",
+    appraisalBody:
+      "Appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details.",
+    buyingTitle: "Buying",
+    buyingBody:
+      "Appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details.",
+    sellingTitle: "Selling",
+    sellingBody:
+      "Appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details.",
+  },
+  contact: {
+    title: "Get in Touch",
+    intro:
+      "Ready to buy, sell, or have questions about the market? Send a message or give me a call.",
+    sectionTitle: "Other ways to reach me",
+    mobile: "(519) 500-1641",
+    office: "(519) 888-7778",
+    fax: "(519) 954-7575",
+    email: "brad@mres.ca",
+    addressLine1: "368 Ash Tree Place",
+    addressLine2: "Waterloo, ON N2T 1R7",
+    facebookUrl: "https://www.facebook.com/ennsrealestate",
+    linkedinUrl: "https://ca.linkedin.com/pub/brad-enns/44/75b/5b9",
+  },
+  footer: {
+    copyright: "Brad Enns. Kitchener–Waterloo & area.",
+    facebookUrl: "https://www.facebook.com/ennsrealestate",
+    linkedinUrl: "https://ca.linkedin.com/pub/brad-enns/44/75b/5b9",
+  },
+};
+
+export function getDefaultSiteContent<K extends SiteContentKey>(key: K): SiteContentPayload<K> {
+  return { ...DEFAULTS[key] };
+}

--- a/src/lib/content/editor-fields.ts
+++ b/src/lib/content/editor-fields.ts
@@ -1,0 +1,68 @@
+import type { SiteContentKey } from "@/lib/content/keys";
+
+export type ContentEditorField = {
+  name: string;
+  label: string;
+  multiline?: boolean;
+};
+
+export const SITE_CONTENT_EDITOR_FIELDS: Record<SiteContentKey, ContentEditorField[]> = {
+  homepage: [
+    { name: "heroEyebrow", label: "Hero eyebrow" },
+    { name: "heroTitle", label: "Hero title" },
+    { name: "heroDescription", label: "Hero description", multiline: true },
+    { name: "heroCtaLabel", label: "Hero button label" },
+    { name: "primaryCtaLabel", label: "Primary button label" },
+    { name: "secondaryCtaLabel", label: "Secondary button label" },
+    { name: "sectionTitle", label: "Services section title" },
+    { name: "buyingTitle", label: "Buying card title" },
+    { name: "buyingText", label: "Buying card text", multiline: true },
+    { name: "sellingTitle", label: "Selling card title" },
+    { name: "sellingText", label: "Selling card text", multiline: true },
+    { name: "appraisalsTitle", label: "Appraisals card title" },
+    { name: "appraisalsText", label: "Appraisals card text", multiline: true },
+    { name: "footerNote", label: "Footer note", multiline: true },
+  ],
+  about: [
+    { name: "eyebrow", label: "Eyebrow" },
+    { name: "headline", label: "Headline" },
+    { name: "bio", label: "Bio", multiline: true },
+    { name: "subheading", label: "Subheading" },
+    { name: "subBio", label: "Sub bio", multiline: true },
+    { name: "stat1Value", label: "Stat 1 value" },
+    { name: "stat1Label", label: "Stat 1 label" },
+    { name: "stat2Value", label: "Stat 2 value" },
+    { name: "stat2Label", label: "Stat 2 label" },
+    { name: "phone", label: "Phone display" },
+    { name: "email", label: "Email display" },
+    { name: "ctaLabel", label: "CTA button label" },
+  ],
+  services: [
+    { name: "heroTitle", label: "Page title" },
+    { name: "heroDescription", label: "Intro", multiline: true },
+    { name: "appraisalTitle", label: "Appraisal card title" },
+    { name: "appraisalBody", label: "Appraisal card body", multiline: true },
+    { name: "buyingTitle", label: "Buying card title" },
+    { name: "buyingBody", label: "Buying card body", multiline: true },
+    { name: "sellingTitle", label: "Selling card title" },
+    { name: "sellingBody", label: "Selling card body", multiline: true },
+  ],
+  contact: [
+    { name: "title", label: "Page title" },
+    { name: "intro", label: "Intro", multiline: true },
+    { name: "sectionTitle", label: "Contact info section title" },
+    { name: "mobile", label: "Mobile phone" },
+    { name: "office", label: "Office phone" },
+    { name: "fax", label: "Fax" },
+    { name: "email", label: "Email" },
+    { name: "addressLine1", label: "Address line 1" },
+    { name: "addressLine2", label: "Address line 2" },
+    { name: "facebookUrl", label: "Facebook URL" },
+    { name: "linkedinUrl", label: "LinkedIn URL" },
+  ],
+  footer: [
+    { name: "copyright", label: "Copyright line" },
+    { name: "facebookUrl", label: "Facebook URL" },
+    { name: "linkedinUrl", label: "LinkedIn URL" },
+  ],
+};

--- a/src/lib/content/keys.ts
+++ b/src/lib/content/keys.ts
@@ -1,0 +1,51 @@
+export const SITE_CONTENT_KEYS = [
+  "homepage",
+  "about",
+  "services",
+  "contact",
+  "footer",
+] as const;
+
+export type SiteContentKey = (typeof SITE_CONTENT_KEYS)[number];
+
+export function isSiteContentKey(value: string): value is SiteContentKey {
+  return (SITE_CONTENT_KEYS as readonly string[]).includes(value);
+}
+
+export const SITE_CONTENT_PAGES: {
+  key: SiteContentKey;
+  label: string;
+  description: string;
+  publicPath: string;
+}[] = [
+  {
+    key: "homepage",
+    label: "Homepage",
+    description: "Hero, calls to action, and services overview on the home page.",
+    publicPath: "/",
+  },
+  {
+    key: "about",
+    label: "About",
+    description: "Headline, bio, stats, and contact details on the about page.",
+    publicPath: "/about",
+  },
+  {
+    key: "services",
+    label: "Services",
+    description: "Intro and service card copy on the services page.",
+    publicPath: "/services",
+  },
+  {
+    key: "contact",
+    label: "Contact",
+    description: "Heading, intro, and contact information on the contact page.",
+    publicPath: "/contact",
+  },
+  {
+    key: "footer",
+    label: "Footer",
+    description: "Footer copyright and social links (used when the site footer is enabled).",
+    publicPath: "/",
+  },
+];

--- a/src/lib/content/merge.ts
+++ b/src/lib/content/merge.ts
@@ -1,0 +1,29 @@
+import { getDefaultSiteContent } from "@/lib/content/defaults";
+import type { SiteContentKey } from "@/lib/content/keys";
+import type { SiteContentPayload } from "@/lib/content/types";
+
+function asString(value: unknown, fallback: string) {
+  return typeof value === "string" ? value : fallback;
+}
+
+/** Merges a stored JSON payload with typed defaults so public pages always have full objects. */
+export function mergeSiteContentPayload<K extends SiteContentKey>(
+  key: K,
+  raw: Record<string, unknown> | null | undefined,
+): SiteContentPayload<K> {
+  const defaults = getDefaultSiteContent(key);
+
+  if (!raw) {
+    return defaults;
+  }
+
+  const entries = Object.entries(defaults).map(([field, fallback]) => [
+    field,
+    asString(raw[field], fallback),
+  ]);
+
+  return {
+    ...defaults,
+    ...Object.fromEntries(entries),
+  } as SiteContentPayload<K>;
+}

--- a/src/lib/content/query.ts
+++ b/src/lib/content/query.ts
@@ -1,0 +1,46 @@
+import { getDefaultSiteContent } from "@/lib/content/defaults";
+import type { SiteContentKey } from "@/lib/content/keys";
+import { mergeSiteContentPayload } from "@/lib/content/merge";
+import type { SiteContentRow } from "@/lib/content/types";
+import { getSiteContent } from "@/lib/store/memory";
+import { getSupabaseReadClient, hasSupabaseReadConfig } from "@/lib/supabase/server";
+
+export async function fetchSiteContent<K extends SiteContentKey>(key: K): Promise<SiteContentRow<K>> {
+  const defaults = getDefaultSiteContent(key);
+
+  if (!hasSupabaseReadConfig()) {
+    const row = getSiteContent(key);
+    return {
+      pageKey: key,
+      payload: mergeSiteContentPayload(key, row?.payload),
+      updatedAt: row?.updated_at ?? null,
+    };
+  }
+
+  const supabase = getSupabaseReadClient();
+  const { data, error } = await supabase
+    .from("site_content")
+    .select("page_key,payload,updated_at")
+    .eq("page_key", key)
+    .maybeSingle();
+
+  if (error) {
+    const row = getSiteContent(key);
+    return {
+      pageKey: key,
+      payload: mergeSiteContentPayload(key, row?.payload),
+      updatedAt: row?.updated_at ?? null,
+    };
+  }
+
+  const rawPayload =
+    data && typeof data.payload === "object" && data.payload !== null
+      ? (data.payload as Record<string, unknown>)
+      : undefined;
+
+  return {
+    pageKey: key,
+    payload: mergeSiteContentPayload(key, rawPayload ?? defaults),
+    updatedAt: typeof data?.updated_at === "string" ? data.updated_at : null,
+  };
+}

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -1,0 +1,80 @@
+import type { SiteContentKey } from "@/lib/content/keys";
+
+export type HomepageContent = {
+  heroEyebrow: string;
+  heroTitle: string;
+  heroDescription: string;
+  heroCtaLabel: string;
+  primaryCtaLabel: string;
+  secondaryCtaLabel: string;
+  sectionTitle: string;
+  buyingTitle: string;
+  buyingText: string;
+  sellingTitle: string;
+  sellingText: string;
+  appraisalsTitle: string;
+  appraisalsText: string;
+  footerNote: string;
+};
+
+export type AboutContent = {
+  eyebrow: string;
+  headline: string;
+  bio: string;
+  subheading: string;
+  subBio: string;
+  stat1Value: string;
+  stat1Label: string;
+  stat2Value: string;
+  stat2Label: string;
+  phone: string;
+  email: string;
+  ctaLabel: string;
+};
+
+export type ServicesContent = {
+  heroTitle: string;
+  heroDescription: string;
+  appraisalTitle: string;
+  appraisalBody: string;
+  buyingTitle: string;
+  buyingBody: string;
+  sellingTitle: string;
+  sellingBody: string;
+};
+
+export type ContactContent = {
+  title: string;
+  intro: string;
+  sectionTitle: string;
+  mobile: string;
+  office: string;
+  fax: string;
+  email: string;
+  addressLine1: string;
+  addressLine2: string;
+  facebookUrl: string;
+  linkedinUrl: string;
+};
+
+export type FooterContent = {
+  copyright: string;
+  facebookUrl: string;
+  linkedinUrl: string;
+};
+
+export type SiteContentPayloadMap = {
+  homepage: HomepageContent;
+  about: AboutContent;
+  services: ServicesContent;
+  contact: ContactContent;
+  footer: FooterContent;
+};
+
+export type SiteContentPayload<K extends SiteContentKey = SiteContentKey> = SiteContentPayloadMap[K];
+
+export type SiteContentRow<K extends SiteContentKey = SiteContentKey> = {
+  pageKey: K;
+  payload: SiteContentPayload<K>;
+  updatedAt: string | null;
+};

--- a/src/lib/store/memory.ts
+++ b/src/lib/store/memory.ts
@@ -1,12 +1,9 @@
 import { randomUUID } from "crypto";
+import { getDefaultSiteContent } from "@/lib/content/defaults";
+import { SITE_CONTENT_KEYS, type SiteContentKey } from "@/lib/content/keys";
+import type { SiteContentPayload } from "@/lib/content/types";
 import type { ListQuery } from "@/lib/listings/query";
-import type {
-  ContactSubmissionRow,
-  ListingRow,
-  ReviewRow,
-  ServiceRow,
-  SiteContentKey,
-} from "@/lib/store/types";
+import type { ContactSubmissionRow, ListingRow, ReviewRow, ServiceRow } from "@/lib/store/types";
 
 /** Seed `created_by` id for demo listings in the in-memory store. */
 const ADMIN_USER_ID = "00000000-0000-0000-0000-000000000001";
@@ -117,34 +114,18 @@ const seedServices: ServiceRow[] = [
   },
 ];
 
-const homepagePayload = {
-  aboutSummary:
-    "Local Kitchener-Waterloo real estate focused on clear guidance and steady communication.",
-  featuredListingIds: [] as string[],
-  servicesLinks: [
-    { label: "Buying", href: "/services#buying" },
-    { label: "Selling", href: "/services#selling" },
-    { label: "Home appraisal", href: "/services#appraisal" },
-  ],
-};
-
-const aboutPayload = {
-  headline: "About Brad",
-  bio: "Placeholder bio. Replace with Brad's story, credentials, and neighbourhoods served.",
-  contactEmail: "brad@example.com",
-  contactPhone: "(519) 555-0100",
-};
-
 let listings = [...seedListings];
 let reviews = [...seedReviews];
 const services = [...seedServices];
 const siteContent: Record<
   SiteContentKey,
-  { payload: Record<string, unknown>; updated_at: string }
-> = {
-  homepage: { payload: homepagePayload, updated_at: nowIso() },
-  about: { payload: aboutPayload, updated_at: nowIso() },
-};
+  { payload: SiteContentPayload<SiteContentKey>; updated_at: string }
+> = Object.fromEntries(
+  SITE_CONTENT_KEYS.map((key) => [
+    key,
+    { payload: getDefaultSiteContent(key), updated_at: nowIso() },
+  ]),
+) as Record<SiteContentKey, { payload: SiteContentPayload<SiteContentKey>; updated_at: string }>;
 let contactSubmissions: ContactSubmissionRow[] = [];
 
 /**
@@ -305,11 +286,22 @@ export function listServices(): ServiceRow[] {
 }
 
 /**
- * @param key - `"homepage"` or `"about"`.
  * @returns Payload and `updated_at` for CMS-style content, or `undefined` if missing.
  */
-export function getSiteContent(key: SiteContentKey) {
-  return siteContent[key];
+export function getSiteContent<K extends SiteContentKey>(key: K) {
+  return siteContent[key] as { payload: SiteContentPayload<K>; updated_at: string } | undefined;
+}
+
+export function upsertSiteContent<K extends SiteContentKey>(
+  key: K,
+  payload: SiteContentPayload<K>,
+) {
+  const row = {
+    payload,
+    updated_at: nowIso(),
+  };
+  siteContent[key] = row as (typeof siteContent)[K];
+  return siteContent[key] as { payload: SiteContentPayload<K>; updated_at: string };
 }
 
 /**

--- a/src/lib/store/types.ts
+++ b/src/lib/store/types.ts
@@ -68,7 +68,7 @@ export type ServiceRow = {
 };
 
 /** Keys for CMS-style JSON blobs in `site_content`. */
-export type SiteContentKey = "homepage" | "about";
+export type { SiteContentKey } from "@/lib/content/keys";
 
 /** Persisted contact or valuation form submission. */
 export type ContactSubmissionRow = {

--- a/src/lib/validations/site-content.ts
+++ b/src/lib/validations/site-content.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+import { SITE_CONTENT_KEYS } from "@/lib/content/keys";
+
+const optionalText = z.string().max(8000);
+
+export const homepageContentSchema = z.object({
+  heroEyebrow: optionalText,
+  heroTitle: optionalText,
+  heroDescription: optionalText,
+  heroCtaLabel: optionalText,
+  primaryCtaLabel: optionalText,
+  secondaryCtaLabel: optionalText,
+  sectionTitle: optionalText,
+  buyingTitle: optionalText,
+  buyingText: optionalText,
+  sellingTitle: optionalText,
+  sellingText: optionalText,
+  appraisalsTitle: optionalText,
+  appraisalsText: optionalText,
+  footerNote: optionalText,
+});
+
+export const aboutContentSchema = z.object({
+  eyebrow: optionalText,
+  headline: optionalText,
+  bio: optionalText,
+  subheading: optionalText,
+  subBio: optionalText,
+  stat1Value: optionalText,
+  stat1Label: optionalText,
+  stat2Value: optionalText,
+  stat2Label: optionalText,
+  phone: optionalText,
+  email: optionalText,
+  ctaLabel: optionalText,
+});
+
+export const servicesContentSchema = z.object({
+  heroTitle: optionalText,
+  heroDescription: optionalText,
+  appraisalTitle: optionalText,
+  appraisalBody: optionalText,
+  buyingTitle: optionalText,
+  buyingBody: optionalText,
+  sellingTitle: optionalText,
+  sellingBody: optionalText,
+});
+
+export const contactContentSchema = z.object({
+  title: optionalText,
+  intro: optionalText,
+  sectionTitle: optionalText,
+  mobile: optionalText,
+  office: optionalText,
+  fax: optionalText,
+  email: optionalText,
+  addressLine1: optionalText,
+  addressLine2: optionalText,
+  facebookUrl: optionalText,
+  linkedinUrl: optionalText,
+});
+
+export const footerContentSchema = z.object({
+  copyright: optionalText,
+  facebookUrl: optionalText,
+  linkedinUrl: optionalText,
+});
+
+export const siteContentSchemas = {
+  homepage: homepageContentSchema,
+  about: aboutContentSchema,
+  services: servicesContentSchema,
+  contact: contactContentSchema,
+  footer: footerContentSchema,
+} as const;
+
+export const siteContentKeySchema = z.enum(SITE_CONTENT_KEYS);

--- a/supabase/migrations/expand_site_content_pages.sql
+++ b/supabase/migrations/expand_site_content_pages.sql
@@ -1,0 +1,104 @@
+  -- Site content table + seeds for editable marketing page copy.
+  -- Safe to run if the table does not exist yet (creates it first).
+
+  create table if not exists public.site_content (
+    page_key text primary key,
+    payload jsonb not null default '{}'::jsonb,
+    updated_at timestamptz not null default now()
+  );
+
+  alter table public.site_content enable row level security;
+
+  drop policy if exists "Public can read site content" on public.site_content;
+  create policy "Public can read site content"
+    on public.site_content for select
+    using (true);
+
+  alter table public.site_content drop constraint if exists site_content_page_key_check;
+
+  alter table public.site_content
+    add constraint site_content_page_key_check
+    check (page_key in ('homepage', 'about', 'services', 'contact', 'footer'));
+
+  insert into public.site_content (page_key, payload)
+  values
+    (
+      'services',
+      jsonb_build_object(
+        'heroTitle', 'Enns Real Estate Services',
+        'heroDescription', 'We''re here to help you value, buy, and sell your home.',
+        'appraisalTitle', 'Home Appraisal',
+        'appraisalBody', 'Appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details.',
+        'buyingTitle', 'Buying',
+        'buyingBody', 'Appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details.',
+        'sellingTitle', 'Selling',
+        'sellingBody', 'Appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details.'
+      )
+    ),
+    (
+      'contact',
+      jsonb_build_object(
+        'title', 'Get in Touch',
+        'intro', 'Ready to buy, sell, or have questions about the market? Send a message or give me a call.',
+        'sectionTitle', 'Other ways to reach me',
+        'mobile', '(519) 500-1641',
+        'office', '(519) 888-7778',
+        'fax', '(519) 954-7575',
+        'email', 'brad@mres.ca',
+        'addressLine1', '368 Ash Tree Place',
+        'addressLine2', 'Waterloo, ON N2T 1R7',
+        'facebookUrl', 'https://www.facebook.com/ennsrealestate',
+        'linkedinUrl', 'https://ca.linkedin.com/pub/brad-enns/44/75b/5b9'
+      )
+    ),
+    (
+      'footer',
+      jsonb_build_object(
+        'copyright', 'Brad Enns. Kitchener–Waterloo & area.',
+        'facebookUrl', 'https://www.facebook.com/ennsrealestate',
+        'linkedinUrl', 'https://ca.linkedin.com/pub/brad-enns/44/75b/5b9'
+      )
+    )
+  on conflict (page_key) do nothing;
+
+  insert into public.site_content (page_key, payload)
+  values (
+    'homepage',
+    jsonb_build_object(
+    'heroEyebrow', 'Kitchener, Waterloo',
+    'heroTitle', 'Enns Real Estate',
+    'heroDescription', 'Real estate and brief agent description. Real estate and brief agent description. Real estate and brief agent description.',
+    'heroCtaLabel', 'LEARN MORE',
+    'primaryCtaLabel', 'View listings',
+      'secondaryCtaLabel', 'Contact Brad',
+      'sectionTitle', 'How I can help',
+      'buyingTitle', 'Buying',
+      'buyingText', 'Strategy for homes that fit your budget, neighbourhood, and timeline.',
+      'sellingTitle', 'Selling',
+      'sellingText', 'Pricing context, presentation, and negotiation with less guesswork.',
+      'appraisalsTitle', 'Appraisals',
+      'appraisalsText', 'Context on value and what to expect when numbers land on paper.',
+      'footerNote', 'Placeholder copy. Replace with Brad''s voice, neighbourhoods, and credentials.'
+    )
+  )
+  on conflict (page_key) do nothing;
+
+  insert into public.site_content (page_key, payload)
+  values (
+    'about',
+    jsonb_build_object(
+      'eyebrow', 'Kitchener, Waterloo Real Estate Agent',
+      'headline', 'Meet Brad Enns',
+      'bio', 'Placeholder bio. Replace with Brad''s story, credentials, and neighbourhoods served.',
+      'subheading', 'Another heading / What I do',
+      'subBio', 'appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details appraisal details',
+      'stat1Value', '20+',
+      'stat1Label', 'homes sold',
+      'stat2Value', '5+',
+      'stat2Label', 'years of experience',
+      'phone', '519 - 500 - 1641',
+      'email', 'brad@mres.ca',
+      'ctaLabel', 'Contact Brad Today'
+    )
+  )
+  on conflict (page_key) do nothing;


### PR DESCRIPTION
## Summary
- add Supabase-backed site_content storage with typed defaults, merge helpers, and Zod validation for homepage, about, services, contact, and footer
- add /admin/content hub and per-page editors with GET/PUT admin APIs and public GET /api/content/[key]
- wire marketing pages and CMS-driven SiteFooter to fetchSiteContent; homepage hero copy flows through HomeHero
- restore SiteFooter in layout via SiteChrome; add SQL migration with table creation, RLS, and seed payloads
- add dashboard quick actions for listings and site content; fix mobile header nav item export

## Commits
1. feat(admin): add editable site content CMS
2. fix(admin): dashboard action buttons and mobile nav items

## Test plan
- [ ] Run supabase/migrations/expand_site_content_pages.sql in Supabase SQL editor (or apply via migration pipeline)
- [ ] Sign in at /admin/login and open /admin/content
- [ ] Edit homepage copy, save, and confirm / reflects changes after refresh
- [ ] Edit footer links/copyright and confirm footer updates on public pages
- [ ] Verify /about, /services, and /contact load CMS copy
- [ ] Confirm /admin/dashboard shows View public listings, Manage listings, and Edit site content buttons
- [ ] npm run build

Closes #31

Made with [Cursor](https://cursor.com)