### PR TITLE
fix(admin): remove overflowing dashboard listing overview actions

### DIFF
--- a/src/components/admin/admin-dashboard-overview.tsx
+++ b/src/components/admin/admin-dashboard-overview.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 
 import { RecentLeadsSection } from "@/components/admin/recent-leads-section";
 import type { DashboardLead, ListingStatusCounts } from "@/lib/admin/dashboard-data";
-import { Button } from "@/components/ui/button";
 
 type AdminDashboardOverviewProps = {
   counts: ListingStatusCounts;
@@ -60,27 +59,6 @@ export function AdminDashboardOverview({ counts, leads }: AdminDashboardOverview
               <p className="mt-1 text-xs opacity-80">{hint}</p>
             </div>
           ))}
-        </div>
-        <p className="mt-3 text-sm text-slate-600">
-          {counts.total} listing{counts.total === 1 ? "" : "s"} total. Manage listings from the{" "}
-          <Link
-            href="/admin/listings"
-            className="font-medium text-[#3A6696] underline-offset-2 hover:underline"
-          >
-            Listings
-          </Link>{" "}
-          page in the nav.
-        </p>
-        <div className="mt-4 flex w-full gap-2 sm:gap-3">
-          <Button variant="outline" className="h-11 min-h-11 flex-1 basis-0 px-2 text-center text-sm" asChild>
-            <Link href="/listings">View public listings</Link>
-          </Button>
-          <Button className="h-11 min-h-11 flex-1 basis-0 px-2 text-center text-sm" asChild>
-            <Link href="/admin/listings">Manage listings</Link>
-          </Button>
-          <Button variant="outline" className="h-11 min-h-11 flex-1 basis-0 px-2 text-center text-sm" asChild>
-            <Link href="/admin/content">Edit site content</Link>
-          </Button>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- Fixes #48 by removing the quick-action button row and helper copy from the admin dashboard **Listing overview** section.

## Test plan

- [ ] Open `/admin/dashboard` on desktop and mobile widths
- [ ] Confirm **Listing overview** shows only Active/Sold count cards (no overflow or horizontal scroll)
- [ ] Confirm **Edit site content** and **Client reviews** cards below still link correctly

Closes #48