### PR TITLE
fix(content): CMS updates on Vercel and save toast feedback

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -10,6 +10,8 @@ export const metadata: Metadata = {
   description: "About Brad Enns and real estate services in Kitchener–Waterloo.",
 };
 
+export const dynamic = "force-dynamic";
+
 function digitsOnly(value: string) {
   return value.replace(/\D/g, "");
 }

--- a/src/app/api/admin/content/[key]/route.ts
+++ b/src/app/api/admin/content/[key]/route.ts
@@ -2,6 +2,7 @@ import { jsonError, jsonOk } from "@/lib/api/http";
 import { requireAdmin } from "@/lib/auth/admin";
 import { upsertSiteContent } from "@/lib/content/admin";
 import { isSiteContentKey } from "@/lib/content/keys";
+import { revalidateSiteContent } from "@/lib/content/revalidate";
 import { fetchSiteContent } from "@/lib/content/query";
 import { siteContentSchemas } from "@/lib/validations/site-content";
 
@@ -59,6 +60,7 @@ export async function PUT(request: Request, ctx: Params) {
 
   try {
     const row = await upsertSiteContent(key, parsed.data);
+    revalidateSiteContent(key);
     return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
   } catch (e) {
     const message = e instanceof Error ? e.message : "Failed to save content";

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -8,6 +8,8 @@ export const metadata: Metadata = {
   description: "Get in touch with Brad Enns.",
 };
 
+export const dynamic = "force-dynamic";
+
 function digitsOnly(value: string) {
   return value.replace(/\D/g, "");
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import { HomeHero } from "@/components/home/home-hero";
 import { fetchSiteContent } from "@/lib/content/query";
 
+export const dynamic = "force-dynamic";
+
 export default async function HomePage() {
   const { payload } = await fetchSiteContent("homepage");
 

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -14,6 +14,8 @@ export const metadata: Metadata = {
   description: "Enns Real Estate services in Kitchener–Waterloo and surrounding communities.",
 };
 
+export const dynamic = "force-dynamic";
+
 export default async function ServicesPage() {
   const { payload: c } = await fetchSiteContent("services");
 

--- a/src/components/admin/listings-editor/editor-toast.tsx
+++ b/src/components/admin/listings-editor/editor-toast.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import { Check, X } from "lucide-react";
+
 type EditorToastProps = {
   message: string;
   onDismiss: () => void;
 };
 
 function isErrorMessage(message: string) {
-  return /fail|error|could not|invalid|required/i.test(message);
+  return /fail|error|could not|invalid|required|must sign in/i.test(message);
 }
 
 export function EditorToast({ message, onDismiss }: EditorToastProps) {
@@ -22,6 +24,14 @@ export function EditorToast({ message, onDismiss }: EditorToastProps) {
       role="status"
       aria-live="polite"
     >
+      <span
+        className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full ${
+          error ? "bg-red-100 text-red-600" : "bg-emerald-100 text-emerald-600"
+        }`}
+        aria-hidden
+      >
+        {error ? <X className="h-3.5 w-3.5" strokeWidth={2.5} /> : <Check className="h-3.5 w-3.5" strokeWidth={2.5} />}
+      </span>
       <p className="flex-1 leading-snug">{message}</p>
       <button
         type="button"

--- a/src/components/admin/site-content-editor.tsx
+++ b/src/components/admin/site-content-editor.tsx
@@ -71,7 +71,7 @@ export function SiteContentEditor({ pageKey, initialPayload, updatedAt }: SiteCo
       if (!res.ok) {
         throw new Error(data?.error?.message ?? "Could not save content.");
       }
-      setMessage("Saved. Refresh the public page to confirm.");
+      setMessage("Saved. Public pages should update on the next visit.");
       router.refresh();
     } catch (err) {
       setMessage(err instanceof Error ? err.message : "Could not save content.");

--- a/src/components/admin/site-content-editor.tsx
+++ b/src/components/admin/site-content-editor.tsx
@@ -2,8 +2,9 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { EditorToast } from "@/components/admin/listings-editor/editor-toast";
 import { SITE_CONTENT_PAGES } from "@/lib/content/keys";
 import { SITE_CONTENT_EDITOR_FIELDS } from "@/lib/content/editor-fields";
 import type { SiteContentKey } from "@/lib/content/keys";
@@ -42,6 +43,14 @@ export function SiteContentEditor({ pageKey, initialPayload, updatedAt }: SiteCo
   const [form, setForm] = useState(() => payloadToFormState(initialPayload));
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (!message) {
+      return;
+    }
+    const timer = window.setTimeout(() => setMessage(""), 5000);
+    return () => window.clearTimeout(timer);
+  }, [message]);
 
   function setField(name: string, value: string) {
     setForm((prev) => ({ ...prev, [name]: value }));
@@ -83,7 +92,9 @@ export function SiteContentEditor({ pageKey, initialPayload, updatedAt }: SiteCo
   const title = page?.label ?? pageKey;
 
   return (
-    <div className="mx-auto flex h-[calc(100dvh-var(--site-header-offset)-3rem)] w-full min-h-0 max-w-3xl flex-col sm:h-[calc(100dvh-9rem)]">
+    <>
+      {message ? <EditorToast message={message} onDismiss={() => setMessage("")} /> : null}
+      <div className="mx-auto flex h-[calc(100dvh-var(--site-header-offset)-3rem)] w-full min-h-0 max-w-3xl flex-col sm:h-[calc(100dvh-9rem)]">
       <header className="shrink-0">
         <h1 className={EDITOR_TITLE_CLASS}>{title}</h1>
         {page?.description ? (
@@ -132,14 +143,6 @@ export function SiteContentEditor({ pageKey, initialPayload, updatedAt }: SiteCo
               </label>
             ))}
           </div>
-
-          {message ? (
-            <p
-              className={`mt-4 text-center text-sm ${message.startsWith("Saved") ? "text-[#3A6696]" : "text-red-600"}`}
-            >
-              {message}
-            </p>
-          ) : null}
         </div>
 
         <div className="flex shrink-0 flex-col-reverse gap-4 pb-6 pt-8 sm:flex-row sm:items-center sm:justify-between sm:pb-8 sm:pt-12">
@@ -151,6 +154,7 @@ export function SiteContentEditor({ pageKey, initialPayload, updatedAt }: SiteCo
           </button>
         </div>
       </form>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/lib/content/revalidate.ts
+++ b/src/lib/content/revalidate.ts
@@ -1,0 +1,22 @@
+import { revalidatePath } from "next/cache";
+
+import type { SiteContentKey } from "@/lib/content/keys";
+import { SITE_CONTENT_PAGES } from "@/lib/content/keys";
+
+const MARKETING_PATHS = ["/", "/about", "/services", "/contact"] as const;
+
+/** Bust Next.js route cache for public pages that read `site_content`. */
+export function revalidateSiteContent(key: SiteContentKey) {
+  if (key === "footer") {
+    for (const path of MARKETING_PATHS) {
+      revalidatePath(path);
+    }
+    revalidatePath("/", "layout");
+    return;
+  }
+
+  const page = SITE_CONTENT_PAGES.find((entry) => entry.key === key);
+  if (page) {
+    revalidatePath(page.publicPath);
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #50 by revalidating marketing pages after CMS saves and rendering CMS-driven routes dynamically so Vercel does not serve stale static builds.
- Replaces inline site content save messages with a top-right toast (checkmark on success, X on error).

## Test plan

- [ ] Edit homepage hero copy in `/admin/content/homepage`, save, then open `/` on Vercel
- [ ] Confirm public homepage shows the saved hero text without redeploying
- [ ] Confirm save success shows a green checkmark toast top-right; failed save shows red X toast
- [ ] Repeat for About, Services, and Contact pages

Closes #50