### PR TITLE
fix(listings): unify toolbar into one desktop row and two mobile rows

### DIFF
--- a/src/components/listings/listings-grid.tsx
+++ b/src/components/listings/listings-grid.tsx
@@ -229,8 +229,8 @@ export function ListingsGrid() {
         })}
       </div>
 
-      <div className="flex flex-col gap-4">
-        <div className="relative w-full sm:max-w-xs sm:self-end">
+      <div className="flex flex-col gap-3 lg:flex-row lg:flex-nowrap lg:items-center lg:gap-2">
+        <div className="relative w-full min-w-0 lg:w-40 lg:shrink-0">
           <input
             type="search"
             placeholder="Search"
@@ -243,91 +243,88 @@ export function ListingsGrid() {
           </span>
         </div>
 
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-wrap items-center justify-center gap-2">
-            <div className="inline-flex overflow-hidden rounded-sm border border-slate-300 bg-white">
-              <button
-                type="button"
-                onClick={() => setFilters((prev) => ({ ...prev, status: "active" }))}
-                className={`border-r px-5 py-2 text-xs font-semibold uppercase tracking-wide ${
-                  filters.status === "active"
-                    ? "border-sky-600 bg-white text-sky-600"
-                    : "border-slate-300 bg-white text-slate-400"
-                }`}
-              >
-                Active
-              </button>
-              <button
-                type="button"
-                onClick={() => setFilters((prev) => ({ ...prev, status: "sold" }))}
-                className={`px-5 py-2 text-xs font-semibold uppercase tracking-wide ${
-                  filters.status === "sold"
-                    ? "bg-white text-sky-600 ring-1 ring-inset ring-sky-600"
-                    : "bg-white text-slate-400"
-                }`}
-              >
-                Sold
-              </button>
-            </div>
-            {admin ? (
-              <Link
-                href="/admin/listings?create=1"
-                className="rounded-sm bg-[#e6e8ec] px-4 py-2 text-sm font-medium text-slate-900 hover:bg-[#d8dadf]"
-              >
-                + Create a new listing
-              </Link>
-            ) : null}
-          </div>
-
-          <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center">
-            <input
-              type="number"
-              min="0"
-              placeholder="Min price"
-              value={filters.minPrice}
-              onChange={(e) => setFilters((prev) => ({ ...prev, minPrice: e.target.value }))}
-              className="min-w-0 rounded-sm border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 sm:w-28"
-            />
-            <input
-              type="number"
-              min="0"
-              placeholder="Max price"
-              value={filters.maxPrice}
-              onChange={(e) => setFilters((prev) => ({ ...prev, maxPrice: e.target.value }))}
-              className="min-w-0 rounded-sm border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 sm:w-28"
-            />
-            <select
-              value={filters.beds}
-              onChange={(e) => setFilters((prev) => ({ ...prev, beds: e.target.value }))}
-              className={`min-w-0 rounded-sm border border-slate-300 bg-white px-3 py-2 text-sm sm:w-36 ${
-                filters.beds ? "text-slate-900" : "text-slate-500"
-              }`}
-            >
-              <option value="">Any beds</option>
-              <option value="1">1 bed</option>
-              <option value="2">2 beds</option>
-              <option value="3">3 beds</option>
-              <option value="4">4 beds</option>
-              <option value="5">5 beds</option>
-            </select>
+        <div className="flex flex-wrap items-center gap-2 lg:contents">
+          <div className="inline-flex shrink-0 overflow-hidden rounded-sm border border-slate-300 bg-white">
             <button
               type="button"
-              onClick={() => {
-                setSearchInput("");
-                setFilters((prev) => ({
-                  ...prev,
-                  minPrice: "",
-                  maxPrice: "",
-                  beds: "",
-                  q: "",
-                  propertyType: "",
-                }));
-              }}
-              className="rounded-sm bg-[#e6e8ec] px-3 py-2 text-sm font-medium text-slate-900 hover:bg-[#d8dadf] sm:w-auto"
+              onClick={() => setFilters((prev) => ({ ...prev, status: "active" }))}
+              className={`border-r px-4 py-2 text-xs font-semibold uppercase tracking-wide sm:px-5 ${
+                filters.status === "active"
+                  ? "border-sky-600 bg-white text-sky-600"
+                  : "border-slate-300 bg-white text-slate-400"
+              }`}
             >
-              Reset
+              Active
+            </button>
+            <button
+              type="button"
+              onClick={() => setFilters((prev) => ({ ...prev, status: "sold" }))}
+              className={`px-4 py-2 text-xs font-semibold uppercase tracking-wide sm:px-5 ${
+                filters.status === "sold"
+                  ? "bg-white text-sky-600 ring-1 ring-inset ring-sky-600"
+                  : "bg-white text-slate-400"
+              }`}
+            >
+              Sold
             </button>
           </div>
+
+          {admin ? (
+            <Link
+              href="/admin/listings?create=1"
+              className="shrink-0 rounded-sm bg-[#e6e8ec] px-3 py-2 text-sm font-medium text-slate-900 hover:bg-[#d8dadf] sm:px-4"
+            >
+              + Create a new listing
+            </Link>
+          ) : null}
+
+          <input
+            type="number"
+            min="0"
+            placeholder="Min price"
+            value={filters.minPrice}
+            onChange={(e) => setFilters((prev) => ({ ...prev, minPrice: e.target.value }))}
+            className="min-w-0 flex-[1_1_7.5rem] rounded-sm border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 lg:w-28 lg:flex-none"
+          />
+          <input
+            type="number"
+            min="0"
+            placeholder="Max price"
+            value={filters.maxPrice}
+            onChange={(e) => setFilters((prev) => ({ ...prev, maxPrice: e.target.value }))}
+            className="min-w-0 flex-[1_1_7.5rem] rounded-sm border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 lg:w-28 lg:flex-none"
+          />
+          <select
+            value={filters.beds}
+            onChange={(e) => setFilters((prev) => ({ ...prev, beds: e.target.value }))}
+            className={`min-w-0 flex-[1_1_7.5rem] rounded-sm border border-slate-300 bg-white px-3 py-2 text-sm lg:w-36 lg:flex-none ${
+              filters.beds ? "text-slate-900" : "text-slate-500"
+            }`}
+          >
+            <option value="">Any beds</option>
+            <option value="1">1 bed</option>
+            <option value="2">2 beds</option>
+            <option value="3">3 beds</option>
+            <option value="4">4 beds</option>
+            <option value="5">5 beds</option>
+          </select>
+          <button
+            type="button"
+            onClick={() => {
+              setSearchInput("");
+              setFilters((prev) => ({
+                ...prev,
+                minPrice: "",
+                maxPrice: "",
+                beds: "",
+                q: "",
+                propertyType: "",
+              }));
+            }}
+            className="shrink-0 rounded-sm bg-[#e6e8ec] px-3 py-2 text-sm font-medium text-slate-900 hover:bg-[#d8dadf]"
+          >
+            Reset
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Fixes #56 by restructuring the public listings toolbar into one aligned row on desktop.
- On mobile, search sits on the first row and the remaining controls wrap on the second row without horizontal scroll.

## Test plan

- [ ] Open `/listings` as admin on desktop and confirm all toolbar controls fit on one line
- [ ] Open `/listings` on mobile and confirm two-row layout with no horizontal page scroll
- [ ] Verify Active/Sold toggle, Create listing, price/beds filters, Reset, and Search still work

Closes #56