### PR TITLE
feat(listings): prefilled contact modal on listing detail

### DIFF
--- a/src/components/contact/contact-form-fields.tsx
+++ b/src/components/contact/contact-form-fields.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Controller, type UseFormReturn } from "react-hook-form";
+
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { ContactPageFormValues } from "@/lib/validations/contact";
+
+type Props = {
+  form: UseFormReturn<ContactPageFormValues>;
+  /** Rows for the message textarea. Modals use a shorter box than the full page. */
+  messageRows?: number;
+  /**
+   * Extra classes for the message textarea. The modal passes a fixed height so
+   * the box scrolls internally instead of growing as more lines are added.
+   */
+  messageClassName?: string;
+};
+
+/**
+ * Shared field set for the contact form. Used by both the `/contact` page form
+ * and the listing inquiry modal so validation and markup stay in one place.
+ */
+export function ContactFormFields({ form, messageRows = 6, messageClassName }: Props) {
+  return (
+    <FieldGroup>
+      <Controller
+        name="name"
+        control={form.control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <FieldLabel htmlFor={field.name}>Name</FieldLabel>
+            <Input
+              {...field}
+              id={field.name}
+              placeholder="Your name"
+              aria-invalid={fieldState.invalid}
+            />
+            {fieldState.error && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+
+      <Controller
+        name="email"
+        control={form.control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <FieldLabel htmlFor={field.name}>Email</FieldLabel>
+            <Input
+              {...field}
+              id={field.name}
+              type="email"
+              placeholder="your.email@example.com"
+              aria-invalid={fieldState.invalid}
+            />
+            {fieldState.error && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+
+      <Controller
+        name="phone"
+        control={form.control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <FieldLabel htmlFor={field.name}>Phone</FieldLabel>
+            <Input
+              {...field}
+              value={field.value ?? ""}
+              id={field.name}
+              type="tel"
+              placeholder="(optional)"
+              aria-invalid={fieldState.invalid}
+            />
+            <FieldDescription>Optional — share this if you’d prefer a call back.</FieldDescription>
+            {fieldState.error && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+
+      <Controller
+        name="subject"
+        control={form.control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <FieldLabel htmlFor={field.name}>Subject</FieldLabel>
+            <Input
+              {...field}
+              id={field.name}
+              placeholder="What's this about?"
+              aria-invalid={fieldState.invalid}
+            />
+            {fieldState.error && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+
+      <Controller
+        name="message"
+        control={form.control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <FieldLabel htmlFor={field.name}>Message</FieldLabel>
+            <Textarea
+              {...field}
+              id={field.name}
+              rows={messageRows}
+              placeholder="Tell me a bit about what you're looking for..."
+              aria-invalid={fieldState.invalid}
+              className={messageClassName}
+            />
+            {fieldState.error && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+
+      {/* Honeypot field: hidden from humans, filled by bots. */}
+      <div className="hidden" aria-hidden="true">
+        <label htmlFor="website">Website</label>
+        <input
+          {...form.register("honeypot")}
+          id="website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+        />
+      </div>
+    </FieldGroup>
+  );
+}

--- a/src/components/contact/contact-form.tsx
+++ b/src/components/contact/contact-form.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import { Button } from "@/components/ui/button";
-import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { FieldGroup } from "@/components/ui/field";
+import { ContactFormFields } from "@/components/contact/contact-form-fields";
 import { contactPageFormSchema, type ContactPageFormValues } from "@/lib/validations/contact";
 import { sendContactEmail } from "@/app/contact/actions";
 
@@ -76,109 +75,7 @@ export function ContactForm() {
 
       <form className="mt-6" noValidate onSubmit={form.handleSubmit(handleSubmit)}>
         <FieldGroup>
-          <Controller
-            name="name"
-            control={form.control}
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid}>
-                <FieldLabel htmlFor={field.name}>Name</FieldLabel>
-                <Input
-                  {...field}
-                  id={field.name}
-                  placeholder="Your name"
-                  aria-invalid={fieldState.invalid}
-                />
-                {fieldState.error && <FieldError errors={[fieldState.error]} />}
-              </Field>
-            )}
-          />
-
-          <Controller
-            name="email"
-            control={form.control}
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid}>
-                <FieldLabel htmlFor={field.name}>Email</FieldLabel>
-                <Input
-                  {...field}
-                  id={field.name}
-                  type="email"
-                  placeholder="your.email@example.com"
-                  aria-invalid={fieldState.invalid}
-                />
-                {fieldState.error && <FieldError errors={[fieldState.error]} />}
-              </Field>
-            )}
-          />
-
-          <Controller
-            name="phone"
-            control={form.control}
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid}>
-                <FieldLabel htmlFor={field.name}>Phone</FieldLabel>
-                <Input
-                  {...field}
-                  value={field.value ?? ""}
-                  id={field.name}
-                  type="tel"
-                  placeholder="(optional)"
-                  aria-invalid={fieldState.invalid}
-                />
-                <FieldDescription>
-                  Optional — share this if you’d prefer a call back.
-                </FieldDescription>
-                {fieldState.error && <FieldError errors={[fieldState.error]} />}
-              </Field>
-            )}
-          />
-
-          <Controller
-            name="subject"
-            control={form.control}
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid}>
-                <FieldLabel htmlFor={field.name}>Subject</FieldLabel>
-                <Input
-                  {...field}
-                  id={field.name}
-                  placeholder="What's this about?"
-                  aria-invalid={fieldState.invalid}
-                />
-                {fieldState.error && <FieldError errors={[fieldState.error]} />}
-              </Field>
-            )}
-          />
-
-          <Controller
-            name="message"
-            control={form.control}
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid}>
-                <FieldLabel htmlFor={field.name}>Message</FieldLabel>
-                <Textarea
-                  {...field}
-                  id={field.name}
-                  rows={6}
-                  placeholder="Tell me a bit about what you're looking for..."
-                  aria-invalid={fieldState.invalid}
-                />
-                {fieldState.error && <FieldError errors={[fieldState.error]} />}
-              </Field>
-            )}
-          />
-
-          {/* Honeypot field: hidden from humans, filled by bots. */}
-          <div className="hidden" aria-hidden="true">
-            <label htmlFor="website">Website</label>
-            <input
-              {...form.register("honeypot")}
-              id="website"
-              type="text"
-              tabIndex={-1}
-              autoComplete="off"
-            />
-          </div>
+          <ContactFormFields form={form} />
 
           {status === "error" && errorMessage && (
             <div

--- a/src/components/listings/listing-contact-dialog.tsx
+++ b/src/components/listings/listing-contact-dialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { Button } from "@/components/ui/button";
+import { FieldGroup } from "@/components/ui/field";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ContactFormFields } from "@/components/contact/contact-form-fields";
+import { contactPageFormSchema, type ContactPageFormValues } from "@/lib/validations/contact";
+import { sendContactEmail } from "@/app/contact/actions";
+
+type Props = {
+  /** Short label for the listing, e.g. the street address or title. */
+  listingLabel: string;
+};
+
+function buildDefaults(listingLabel: string): ContactPageFormValues {
+  return {
+    name: "",
+    email: "",
+    phone: "",
+    subject: `Inquiry about ${listingLabel}`,
+    message: `Hi Brad,\n\nI'm interested in this listing (${listingLabel}). Could you share more details and let me know about next steps?\n\nThanks!`,
+    honeypot: "",
+  };
+}
+
+/**
+ * "Contact Brad about this listing" button that opens a modal with the contact
+ * form prefilled with the listing's subject and a starter message. Submits
+ * through the same server action as the `/contact` page.
+ */
+export function ListingContactDialog({ listingLabel }: Props) {
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const defaultValues = useMemo(() => buildDefaults(listingLabel), [listingLabel]);
+
+  const form = useForm<ContactPageFormValues>({
+    resolver: zodResolver(contactPageFormSchema),
+    defaultValues,
+  });
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      // Reset back to a clean, prefilled form once the close animation starts.
+      form.reset(defaultValues);
+      setStatus("idle");
+      setErrorMessage(null);
+    }
+  };
+
+  const handleSubmit = async (values: ContactPageFormValues) => {
+    setStatus("submitting");
+    setErrorMessage(null);
+
+    try {
+      const result = await sendContactEmail(values);
+
+      if (result.success) {
+        setStatus("success");
+        form.reset(defaultValues);
+      } else {
+        setStatus("error");
+        setErrorMessage(result.error ?? "Something went wrong.");
+      }
+    } catch (error) {
+      console.error("Listing inquiry error:", error);
+      setStatus("error");
+      setErrorMessage(
+        "Something went wrong sending your message. Please try again, or call directly if it's urgent.",
+      );
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center justify-center rounded-md border border-sky-600 bg-white px-4 py-3 text-center text-[11px] font-semibold uppercase tracking-wider text-sky-700 hover:bg-sky-50"
+        >
+          Contact Brad about this listing
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] overflow-y-auto">
+        {status === "success" ? (
+          <div className="py-4 text-center">
+            <DialogTitle className="text-xl">Message sent</DialogTitle>
+            <p className="mx-auto mt-3 max-w-sm text-sm text-zinc-600">
+              Thanks for reaching out about this listing. Brad will get back to you within a day.
+            </p>
+            <Button type="button" className="mt-6" onClick={() => handleOpenChange(false)}>
+              Done
+            </Button>
+          </div>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Contact Brad about this listing</DialogTitle>
+              <DialogDescription>
+                Send a message about {listingLabel}. Brad usually replies within a day.
+              </DialogDescription>
+            </DialogHeader>
+
+            <form noValidate onSubmit={form.handleSubmit(handleSubmit)}>
+              <FieldGroup>
+                <ContactFormFields
+                  form={form}
+                  messageRows={4}
+                  messageClassName="field-sizing-fixed h-28 resize-none overflow-y-auto"
+                />
+
+                {status === "error" && errorMessage && (
+                  <div
+                    role="alert"
+                    className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800"
+                  >
+                    {errorMessage}
+                  </div>
+                )}
+
+                <Button type="submit" className="mt-2 w-full" disabled={status === "submitting"}>
+                  {status === "submitting" ? "Sending..." : "Send Message"}
+                </Button>
+              </FieldGroup>
+            </form>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/listings/listing-detail-view.tsx
+++ b/src/components/listings/listing-detail-view.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { ListingDetailGallery } from "@/components/listings/listing-detail-gallery";
 import { ListingAdminActions } from "@/components/listings/listing-admin-actions";
+import { ListingContactDialog } from "@/components/listings/listing-contact-dialog";
 import {
   amenityIconPath,
   canonicalAmenitiesFromStored,
@@ -139,12 +140,7 @@ export function ListingDetailView({ listing, nearby }: Props) {
             className="h-56 w-full rounded-md border border-slate-200 bg-white"
             referrerPolicy="no-referrer-when-downgrade"
           />
-          <Link
-            href="/contact"
-            className="flex w-full items-center justify-center rounded-md border border-sky-600 bg-white px-4 py-3 text-center text-[11px] font-semibold uppercase tracking-wider text-sky-700 hover:bg-sky-50"
-          >
-            Contact Brad about this listing
-          </Link>
+          <ListingContactDialog listingLabel={listing.address_line || listing.title} />
         </aside>
       </div>
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+const DialogPortal = DialogPrimitive.Portal;
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-zinc-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm text-zinc-400 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 disabled:pointer-events-none">
+          <X className="size-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1.5 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg font-semibold tracking-tight text-zinc-900", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-zinc-500", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogPortal,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+};


### PR DESCRIPTION
## Summary

- Fixes #60 by replacing the listing detail "Contact Brad about this listing" link with an in-place inquiry modal
- Prefills subject and message with the listing address/title so Brad knows which property the visitor means
- Extracts shared `ContactFormFields` so the `/contact` page and listing modal stay in sync
- Adds a reusable Dialog UI primitive and submits through the existing `sendContactEmail` action

## Test plan

- [ ] Open a public listing detail page and click **Contact Brad about this listing**
- [ ] Confirm a modal opens with subject/message prefilled for that listing
- [ ] Submit a valid inquiry and confirm success state + email/lead flow still works
- [ ] Submit with missing required fields and confirm validation errors show in the modal
- [ ] Close/reopen the modal and confirm it resets to the prefilled defaults
- [ ] Confirm `/contact` still renders and submits correctly with the shared fields