### PR TITLE
SEO fundamentals + security hardening

### DIFF
--- a/SETUP_REQUIREMENTS.md
+++ b/SETUP_REQUIREMENTS.md
@@ -34,7 +34,29 @@ Runtime: Node.js
 - Husky and lint-staged are configured
 - Pre-commit runs lint and format on staged files
 
+## Environment Variables
+
+Client-exposed (safe to ship in the browser bundle):
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY` (publishable key)
+- `NEXT_PUBLIC_SITE_URL` — canonical production origin (e.g. `https://www.example.com`), used
+  for canonical URLs, `sitemap.xml`, `robots.txt`, Open Graph URLs, and JSON-LD. Falls back to
+  `VERCEL_PROJECT_PRODUCTION_URL`, then `http://localhost:3000`. **Set this in production** so
+  SEO URLs point at the real domain.
+
+Server-only (never prefix with `NEXT_PUBLIC_`):
+
+- `STORAGE_SUPABASE_SECRET_KEY` (Supabase service role — bypasses RLS)
+- `RESEND_API_KEY` (transactional email)
+- `ADMIN_REGISTRATION_SECRET` — **required to enable admin sign-up.** `POST /api/admin/auth/register`
+  fails closed: if this is unset, admin registration is disabled (503). When set, the `/admin/register`
+  page must supply it in the "Invite code" field (sent as the `x-admin-invite` header).
+- `ADMIN_API_TOKEN` (optional) — static bearer token alternative to Supabase-JWT admin auth.
+- `ADMIN_UI_BYPASS_AUTH` (optional, dev only) — bypasses admin auth; ignored unless `NODE_ENV=development`.
+
 ## Deploy Notes (Vercel)
 
 - `.env.local` is local-only
 - Set the same env vars in Vercel Project Settings -> Environment Variables
+- Security headers (CSP, HSTS, etc.) are applied globally in `next.config.ts`.

--- a/docs/security-audit-status.md
+++ b/docs/security-audit-status.md
@@ -1,0 +1,94 @@
+# Security Audit — Status & Remaining Work
+
+_Branch: `feat/listings-cms-ux` · Last updated: 2026-07-22_
+
+Companion to [`security-audit.md`](./security-audit.md) (the detailed findings). This page is
+the at-a-glance **status board**: what has been done, and what still needs doing before the
+site is production-ready from a security standpoint.
+
+---
+
+## ✅ Done (implemented & verified)
+
+All items below are committed as code changes and verified (`tsc` clean; end-to-end tested
+against a local dev server where noted).
+
+| # | Item | What changed | Verified |
+|---|------|--------------|----------|
+| 1 | **Gated admin registration** (was High-severity: anyone could mint a `role:admin` account) | `POST /api/admin/auth/register` now requires the `ADMIN_REGISTRATION_SECRET` shared secret via the `x-admin-invite` header; fails closed (503) when unset; constant-time secret compare. The `/admin/register` page gained an "Invite code" field. | ✅ 401 on missing/wrong secret, 200 on correct, 503 when unset |
+| 2 | **HTTP security headers** | Added `async headers()` in `next.config.ts`: CSP, HSTS, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`. | ✅ `curl -I` shows all headers on homepage |
+| 3 | **Constant-time `ADMIN_API_TOKEN` compare** | New `src/lib/auth/timing-safe-equal.ts`; replaced `!==` in `src/lib/auth/admin.ts`. | ✅ tsc |
+| 4 | **Tightened search sanitization** | `sanitizeSearchLike` (`src/lib/listings/query.ts`) now allowlists letters/digits/space/hyphen so `. ( ) *` can't distort the PostgREST `.or()` filter. | ✅ odd-char searches return 200, no breakage |
+| 5 | **Generic error responses** | ~13 catch blocks across 8 API routes no longer return `e.message`; detail is logged server-side, clients get a generic message. | ✅ tsc |
+| 6 | **Rate-limit limitation documented** | `src/lib/rate-limit.ts` has a `TODO(security)` explaining the per-process in-memory limitation and the shared-store recommendation. | ✅ |
+| 7 | **Env/setup documentation** | `SETUP_REQUIREMENTS.md` documents all client vs. server-only env vars, including `ADMIN_REGISTRATION_SECRET`. | ✅ |
+
+**Also confirmed OK during the audit (no change needed):** RLS enabled on every table with
+`SELECT`-only public policies scoped to published data; `contact_submissions` locked to
+service-role; all 8 privileged `/api/admin/**` handlers call `requireAdmin`; the three auth
+layers (middleware, page gate, API gate) agree on the admin check; `ADMIN_UI_BYPASS_AUTH` is
+dev-only; upload routes enforce MIME + 10 MB limits behind `requireAdmin`; no secret is read
+from a `NEXT_PUBLIC_*` variable.
+
+---
+
+## ⛔ Remaining — required before production launch
+
+### R1. Rotate the live secrets — **human action, only you can do this**
+`.env.local` holds a real Supabase service-role key (`sb_secret_…`, RLS-bypassing) and a live
+`RESEND_API_KEY`. They are **not** in git (confirmed), but since they've lived on a workstation
+they should be rotated:
+- [ ] Roll the Supabase service-role / secret key in the Supabase dashboard.
+- [ ] Roll the `RESEND_API_KEY` in the Resend dashboard.
+- [ ] Update the new values in Vercel Project Settings → Environment Variables (not `.env.local`).
+
+### R2. Set `ADMIN_REGISTRATION_SECRET` in the deployment environment
+The registration gate fails **closed** — if this var is not set in production, admin sign-up is
+disabled entirely (503). Decide and configure:
+- [ ] Generate a strong random secret and set it in Vercel env (all environments where sign-up
+      should work).
+- [ ] Share it out-of-band with whoever needs to create admin accounts (they enter it in the
+      "Invite code" field on `/admin/register`).
+- [ ] _Alternative for a single-agent site:_ create the one admin account, then **leave the var
+      unset** in production so the route stays disabled. (Your call — see Open Question O1.)
+
+---
+
+## 🔶 Remaining — recommended, not blocking
+
+### R3. Production-grade rate limiting
+Current limiter is per-process/in-memory (best-effort on serverless; resets on redeploy, not
+shared across instances) and only guards the contact form.
+- [ ] Back it with a shared store (Upstash Redis / Vercel KV).
+- [ ] Extend limiting to the admin registration and upload routes.
+- Tracked as `TODO(security)` in `src/lib/rate-limit.ts`.
+
+### R4. Tighten the Content-Security-Policy
+The CSP currently allows `'unsafe-inline'` for `style-src` (and inline scripts for Next.js
+hydration), which is the pragmatic baseline.
+- [ ] Once inline style/script usage is inventoried, move to a **nonce-based** CSP and drop
+      `'unsafe-inline'`. See the comment in `next.config.ts`.
+
+### R5. Optional second-pass review
+- [ ] Run the `/security-review` skill on the branch diff as an independent check before merge.
+
+---
+
+## ❓ Open questions to resolve
+
+- **O1 — Admin registration model:** keep self-serve sign-up gated by the shared secret, or
+  create the single admin once and disable the route (leave `ADMIN_REGISTRATION_SECRET` unset)
+  in production? Current code supports both; it's a config decision.
+- **O2 — Rate-limit store:** wire Upstash/Vercel KV now (R3), or ship with the documented TODO
+  and revisit post-launch?
+
+---
+
+## Quick pre-launch checklist
+
+- [ ] R1 — rotate Supabase + Resend keys, update deployment env
+- [ ] R2 — set (or intentionally omit) `ADMIN_REGISTRATION_SECRET` in production
+- [ ] Confirm security headers on the deployed domain (`curl -I https://<domain>`)
+- [ ] (Recommended) R3 — shared-store rate limiting
+- [ ] (Recommended) R4 — nonce-based CSP
+- [ ] (Recommended) R5 — `/security-review` pass on the diff

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,122 @@
+# Security Audit — Enns Real Estate Site
+
+_Branch: `feat/listings-cms-ux` · Stack: Next.js 16 (App Router), React 19, Supabase, Resend, Zod._
+
+This document records findings from a security pass over the admin/auth surface, the public
+API and input surface, secrets handling, and HTTP hardening. Severity is a pragmatic
+High / Medium / Low. Items marked **Fixed** were addressed in the same change set; items
+marked **Action required** need a human (key rotation, infra).
+
+## Summary
+
+| # | Severity | Finding | Status |
+|---|----------|---------|--------|
+| 1 | **High** | Ungated admin registration endpoint mints `role: admin` users | Fixed (secret gate) |
+| 2 | **Medium** | No HTTP security headers (CSP, HSTS, frame, nosniff, etc.) | Fixed |
+| 3 | Medium | Live service-role + Resend keys present in `.env.local` | Action required (rotate) |
+| 4 | Low | `ADMIN_API_TOKEN` compared with `!==` (timing side-channel) | Fixed (timing-safe) |
+| 5 | Low | `sanitizeSearchLike` allows `. ( ) *` into PostgREST `.or()` filter | Fixed (allowlist) |
+| 6 | Low | Server error messages (`e.message`) returned to clients on 500s | Fixed (generic) |
+| 7 | Low | In-memory rate limiting; only contact form is limited | Documented (see notes) |
+
+## Findings
+
+### 1. Ungated admin registration — HIGH → Fixed
+`src/app/api/admin/auth/register/route.ts` used the **service-role** client to call
+`supabase.auth.admin.createUser({ ..., email_confirm: true, app_metadata: { role: "admin" } })`
+(`src/lib/auth/admin-user-metadata.ts`) with **no authorization gate**. Any unauthenticated
+client that could POST valid JSON to this route received a fully-confirmed admin account with
+complete CMS access (create/edit/delete listings, edit site content, manage reviews, read
+contact leads).
+
+**Fix:** the route now requires a shared secret `ADMIN_REGISTRATION_SECRET`, supplied via the
+`x-admin-invite` request header, and rejects with 401 when it is missing/incorrect (or 503 if
+the secret is not configured on the server, so registration fails closed). Constant-time
+comparison is used to avoid leaking the secret via timing.
+
+### 2. Missing HTTP security headers — MEDIUM → Fixed
+`next.config.ts` previously set only `images.remotePatterns` and `redirects`. No CSP, HSTS,
+`X-Content-Type-Options`, frame protection, `Referrer-Policy`, or `Permissions-Policy`.
+
+**Fix:** added an `async headers()` block applying a baseline set to all routes: HSTS,
+`X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`,
+`X-Frame-Options: DENY`, a restrictive `Permissions-Policy`, and a Content-Security-Policy
+scoped to `'self'` plus the allowed image hosts (`*.supabase.co`, `placehold.co`,
+`images.unsplash.com`). CSP allows the inline styles/fonts Next.js requires
+(`'unsafe-inline'` for `style-src`; `data:`/`blob:` images). See config comments for the
+tightening path (nonces) once inline usage is inventoried.
+
+### 3. Live secrets in `.env.local` — MEDIUM → Action required
+`.env.local` contains a real Supabase service-role key (`sb_secret_…`, RLS-bypassing) and a
+`RESEND_API_KEY`. The file is **not** tracked by git (`.gitignore` covers `.env*`, confirmed
+via `git ls-files`), so this is not a repo leak. However, because these keys have been on a
+developer workstation, rotate both before/at production launch:
+- Supabase: roll the service-role/secret key in the dashboard, update the deployment env.
+- Resend: roll the API key.
+No secret is read from a `NEXT_PUBLIC_*` variable — verified in `src/lib/supabase/server.ts`
+and `src/lib/supabase/public-config.ts` (service key only ever comes from `STORAGE_*` /
+`SUPABASE_*` server vars).
+
+### 4. Static admin token timing side-channel — LOW → Fixed
+`requireAdmin` (`src/lib/auth/admin.ts`) compared `token !== staticAdminToken` with `!==`,
+which short-circuits and is theoretically timing-observable.
+**Fix:** replaced with a constant-time comparison helper (`crypto.timingSafeEqual` on equal-
+length buffers, length-guarded).
+
+### 5. Search sanitization gap — LOW → Fixed
+`sanitizeSearchLike` (`src/lib/listings/query.ts`) stripped `% _ \ ,` but not `.`, `(`, `)`,
+or `*`. The result is interpolated into a PostgREST filter string
+`db.or("title.ilike.%<q>%,city.ilike.%<q>%")`, where `.` `(` `)` are structural characters —
+crafted input could distort the OR expression (query breakage / logic manipulation; not a
+classic SQLi because PostgREST parses the filter grammar, and RLS still bounds results).
+**Fix:** switched to a conservative allowlist (letters, digits, spaces, hyphen) so only
+benign characters reach the filter builder.
+
+### 6. Internal error messages leaked to clients — LOW → Fixed
+Several handlers returned `e.message` on 500 (e.g. `src/app/api/listings/route.ts`,
+`src/app/api/admin/listings/route.ts`, upload routes), which can surface DB/driver detail.
+**Fix:** 500 responses now return a generic message; the detail is logged server-side with
+`console.error`. Validation (4xx) messages remain specific and safe.
+
+### 7. Rate limiting — LOW → Documented
+`src/lib/rate-limit.ts` is a per-process in-memory fixed window (5/hr per IP) applied only to
+the contact server action (`src/app/contact/actions.ts`). On Vercel's serverless/edge runtime
+this state is **not shared across instances** and resets on redeploy, so it is best-effort.
+Notes:
+- The `/api/auth/login` and `/api/auth/register` routes are **unwired placeholders**; real
+  end-user login uses the Supabase client SDK, which Supabase rate-limits server-side.
+- The admin registration route is now secret-gated (finding 1), which removes the practical
+  brute-force concern there.
+- **Recommendation (not blocking):** for production, back rate limiting with a shared store
+  (Upstash Redis / Vercel KV) and extend it to the registration and upload routes. Left as a
+  documented TODO in `src/lib/rate-limit.ts`.
+
+## Things verified as OK (no action)
+- **RLS** is enabled on every table (`supabase/migrations/core_schema_rls_seed.sql`): public
+  `SELECT`-only policies scoped to published data (`listings` active/sold, `reviews`
+  `is_visible`), and `contact_submissions` has **no** anon policies (service-role writes only).
+- **All 8 privileged route handlers** under `src/app/api/admin/**` (except the now-gated
+  `auth/register`) call `requireAdmin` before doing any work.
+- **Three auth layers agree** (middleware, page gate, API gate) on the admin-role check
+  (`isAdminJwtUser`).
+- **`ADMIN_UI_BYPASS_AUTH`** is gated to `NODE_ENV === "development"` and cannot enable in a
+  production build.
+- **Upload route** enforces `image/*` MIME and a 10 MB size cap and is behind `requireAdmin`.
+- The public read client uses the anon/publishable key, so RLS applies to all public reads.
+
+## Verification performed
+
+- `npx tsc --noEmit` — clean. `npm run lint` — only 3 pre-existing errors + 1 warning, all in
+  files untouched by this work (`editor-photos-panel.tsx`, `reviews-manager.tsx`,
+  `revalidate.ts`); no regressions.
+- **Admin registration gate** (`POST /api/admin/auth/register`), against a local dev server:
+  - no `x-admin-invite` header → **401**;
+  - wrong secret → **401** (`Invalid or missing admin invite secret`);
+  - correct secret → passes the gate (**200**, account created).
+  - with `ADMIN_REGISTRATION_SECRET` unset → **503** (fails closed).
+  (The test admin account created by the 200-path was deleted afterward via the service role.)
+- **Security headers** — `curl -I` on the homepage confirmed CSP, HSTS,
+  `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Permissions-Policy`
+  are present.
+- **Search sanitization** — listing search with `)(.* `, `O'Brien`, and `100%off` all return
+  HTTP 200 (no 500, no filter breakage).

--- a/docs/seo-audit.md
+++ b/docs/seo-audit.md
@@ -1,0 +1,104 @@
+# SEO Audit & Improvements — Enns Real Estate Site
+
+_Branch: `feat/listings-cms-ux` · Last updated: 2026-07-22_
+
+A technical-SEO pass over the site: crawlability (robots + sitemap), structured data,
+canonical/social metadata, and caching. The site's value is being found by local buyers and
+sellers in Kitchener–Waterloo, so the focus is on the fundamentals search engines expect.
+
+## Summary
+
+| # | Area | Before | Status |
+|---|------|--------|--------|
+| 1 | Sitemap & robots | none | **Added** (`sitemap.ts`, `robots.ts`) |
+| 2 | Canonical URLs | none | **Added** (every public page) |
+| 3 | `metadataBase` + Open Graph / Twitter | OG on listing detail only, no base | **Added** site-wide + per page |
+| 4 | Structured data (JSON-LD) | none | **Added** (agent, listing, breadcrumb, reviews) |
+| 5 | Admin `noindex` | already present | **Verified OK** |
+| 6 | Caching | `force-dynamic` everywhere | **Improved** on listing routes (ISR + on-demand) |
+| 7 | Image `alt` text | hero empty | **Fixed** hero; grid already had alt |
+
+## What was already good (kept)
+
+- All public pages are server components — fully server-rendered and crawlable.
+- Per-route `metadata` / `generateMetadata` on `/`, `/listings`, `/listings/[id]`, `/about`,
+  `/services`, `/contact`; a title template (`%s | Brad Enns`) in the root layout.
+- `next/image` throughout, with `images.remotePatterns` configured.
+- Ten legacy→new **301 redirects** in `next.config.ts` preserving link equity from the old site.
+- Admin routes already carried `robots: { index: false, follow: false }`.
+
+## Changes implemented
+
+### 1. Sitemap & robots — `src/app/sitemap.ts`, `src/app/robots.ts`
+- `robots.txt`: allows all, disallows `/admin` and `/api`, declares `Host` and points at the
+  sitemap.
+- `sitemap.xml`: five static routes plus **every public listing** (active + sold), pulled from
+  `fetchListings(...)`, using each listing's `updated_at` as `lastModified`. Revalidates hourly
+  so new/sold listings surface without a redeploy. Fails soft to the static routes if listings
+  can't be loaded.
+
+### 2. Canonicals & the site origin — `src/lib/site-config.ts`
+- New `SITE_URL` helper resolves the canonical origin from `NEXT_PUBLIC_SITE_URL`
+  (→ `VERCEL_PROJECT_PRODUCTION_URL` → `http://localhost:3000`). This one value feeds
+  `metadataBase`, canonicals, the sitemap, robots, OG URLs, and JSON-LD `@id`s.
+- `metadataBase` set in the root layout so all relative OG/canonical URLs resolve to absolute.
+- `alternates.canonical` set on `/` (layout default), `/listings`, `/about`, `/services`,
+  `/contact`, and per-listing in `generateMetadata`. (Each page must set its own canonical to
+  override the layout default — done.)
+
+### 3. Open Graph / Twitter — `src/app/layout.tsx` + pages
+- Site-wide default `openGraph` (`type`, `siteName`, `locale: en_CA`, url) and a
+  `twitter: summary_large_image` card in the root layout.
+- Per-page OG title/description/url on the marketing pages.
+- Listing detail: OG **and** Twitter now emit the listing's image as an **absolute** URL
+  (resolved via `metadataBase`), plus `og:url`/canonical.
+
+### 4. Structured data (JSON-LD) — `src/components/seo/json-ld.tsx`
+- Small `<JsonLd>` helper renders `application/ld+json` (allowed by the existing CSP).
+- **`RealEstateAgent`** in the root layout (`@id` `…/#agent`): name, url, `areaServed`
+  (Kitchener, Waterloo, Cambridge, Elmira, New Hamburg), `knowsAbout`, region.
+- **`RealEstateListing` + `BreadcrumbList`** on listing detail: name, description, images,
+  price `Offer` (CAD, in-stock vs. sold-out), postal address, geo coordinates, and a `broker`
+  reference back to the agent `@id`.
+- **`RealEstateAgent` review graph** on `/about`: the featured `Review`s, plus an
+  `AggregateRating` computed from those with a numeric rating (omitted when none are rated).
+
+### 5. Caching — listing routes
+- `/listings` (server shell for a client-fetched grid) and `/sitemap.xml` are now statically
+  cached with hourly ISR (`export const revalidate = 3600`).
+- `/listings/[id]` sets `revalidate = 3600`; the admin **create / update / delete** routes call
+  `revalidatePath("/listings/<id>")` and `revalidatePath("/listings")` so edits and removals
+  propagate immediately rather than waiting out the window.
+- The content-driven marketing pages (`/`, `/about`, `/services`, `/contact`) remain
+  request-time rendered so CMS edits show instantly; content edits already call
+  `revalidatePath` via `revalidateSiteContent`.
+
+### 6. Image alt text — `src/components/home/home-hero.tsx`
+- The hero background image had `alt=""`; it now carries descriptive, location-relevant alt.
+- The listings grid card image already used `alt={listing.title}` — left as is.
+
+## Verification performed
+
+- `npm run build` — clean. Route table shows `/robots.txt`, `/sitemap.xml` (1h), and
+  `/listings` (1h) as static; `tsc` and targeted `eslint` clean.
+- With `NEXT_PUBLIC_SITE_URL` set, against the running server:
+  - `/robots.txt` — correct allow/disallow, host, and sitemap line.
+  - `/sitemap.xml` — static routes + live listing IDs with `lastmod`.
+  - Home `<head>` — canonical, full OG, Twitter card, and `RealEstateAgent` JSON-LD.
+  - Listing `<head>` — canonical, absolute OG/Twitter image, `RealEstateListing` + `BreadcrumbList`.
+  - `/about` — canonical + review JSON-LD.
+  - `/admin/register` — `noindex, nofollow` confirmed.
+
+## Remaining / recommended (not blocking)
+
+- **Set `NEXT_PUBLIC_SITE_URL`** to the real production domain in the deployment env — until
+  then canonicals/sitemap/OG fall back to the Vercel domain (or localhost locally). This is the
+  one required config step for SEO to be fully correct. _(See Open Question O3.)_
+- **Google Search Console**: add a `verification` meta (or DNS record) once you have the token,
+  then submit `sitemap.xml`.
+- **Validate rich results**: after deploy, run Google's Rich Results Test on the home page and a
+  listing URL to confirm the agent/listing/breadcrumb data parses.
+- **Reviews with ratings**: `AggregateRating` only appears once reviews carry a numeric `rating`
+  (current sample reviews have none) — encourage capturing a star rating per review.
+- **Per-listing OG image dimensions**: optionally add width/height to OG images for cleaner
+  social previews.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,52 @@
 import type { NextConfig } from "next";
 
+/**
+ * Content-Security-Policy applied to every route.
+ *
+ * `style-src`/`img-src` are relaxed for what Next.js and the app genuinely need:
+ * - `'unsafe-inline'` styles: Next injects inline `<style>` and style attributes; removing
+ *   this requires a nonce-based pipeline (future hardening — see docs/security-audit.md).
+ * - image hosts mirror `images.remotePatterns` below (Supabase Storage, placehold, Unsplash).
+ * `frame-ancestors 'none'` blocks clickjacking (belt-and-suspenders with X-Frame-Options).
+ */
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  // Next.js App Router streams inline hydration scripts (self.__next_f.push). Without a
+  // nonce pipeline those require 'unsafe-inline'. Tightening to nonces is tracked as follow-up
+  // hardening in docs/security-audit.md.
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://*.supabase.co https://placehold.co https://images.unsplash.com",
+  "font-src 'self' data:",
+  "connect-src 'self' https://*.supabase.co",
+  "upgrade-insecure-requests",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=(), browsing-topics=()" },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+];
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,12 +2,67 @@ import type { Metadata } from "next";
 import Image from "next/image";
 
 import { ClientReviewsSection } from "@/components/reviews/client-reviews-section";
+import { JsonLd, type JsonLdData } from "@/components/seo/json-ld";
 import { fetchSiteContent } from "@/lib/content/query";
 import { fetchFeaturedReviews } from "@/lib/reviews/query";
+import { AGENT_NAME, absoluteUrl } from "@/lib/site-config";
+
+type FeaturedReview = Awaited<ReturnType<typeof fetchFeaturedReviews>>[number];
+
+/** Build `RealEstateAgent` review + aggregate-rating structured data for the About page. */
+function buildReviewsJsonLd(reviews: FeaturedReview[]): JsonLdData | null {
+  if (reviews.length === 0) {
+    return null;
+  }
+  const rated = reviews.filter((r) => typeof r.rating === "number" && r.rating > 0);
+  const reviewNodes = reviews.map((r) => ({
+    "@type": "Review",
+    author: { "@type": "Person", name: r.author_name },
+    ...(r.title ? { name: r.title } : {}),
+    reviewBody: r.body,
+    ...(typeof r.rating === "number" && r.rating > 0
+      ? {
+          reviewRating: {
+            "@type": "Rating",
+            ratingValue: r.rating,
+            bestRating: 5,
+          },
+        }
+      : {}),
+    ...(r.created_at ? { datePublished: r.created_at } : {}),
+  }));
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "RealEstateAgent",
+    "@id": absoluteUrl("/#agent"),
+    name: AGENT_NAME,
+    url: absoluteUrl("/about"),
+    review: reviewNodes,
+    ...(rated.length > 0
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: Number(
+              (rated.reduce((sum, r) => sum + (r.rating as number), 0) / rated.length).toFixed(1),
+            ),
+            reviewCount: rated.length,
+            bestRating: 5,
+          },
+        }
+      : {}),
+  };
+}
 
 export const metadata: Metadata = {
   title: "About",
   description: "About Brad Enns and real estate services in Kitchener–Waterloo.",
+  alternates: { canonical: "/about" },
+  openGraph: {
+    title: "About Brad Enns",
+    description: "About Brad Enns and real estate services in Kitchener–Waterloo.",
+    url: "/about",
+  },
 };
 
 export const dynamic = "force-dynamic";
@@ -23,9 +78,11 @@ export default async function AboutPage() {
   ]);
   const phoneHref = `tel:${digitsOnly(c.phone)}`;
   const emailHref = `mailto:${c.email}`;
+  const reviewsJsonLd = buildReviewsJsonLd(featuredReviews);
 
   return (
     <div className="min-h-screen bg-white">
+      {reviewsJsonLd ? <JsonLd data={reviewsJsonLd} /> : null}
       <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 md:py-8">
         <div className="md:hidden">
           <p className="mb-2 text-base font-medium text-brand-gold">{c.eyebrow}</p>

--- a/src/app/admin/register/page.tsx
+++ b/src/app/admin/register/page.tsx
@@ -50,6 +50,8 @@ export default function AdminRegisterPage() {
 
   const [confirmPassword, setConfirmPassword] = useState("");
 
+  const [inviteCode, setInviteCode] = useState("");
+
   const [busy, setBusy] = useState(false);
 
   const [message, setMessage] = useState("");
@@ -90,7 +92,7 @@ export default function AdminRegisterPage() {
 
         method: "POST",
 
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-admin-invite": inviteCode.trim() },
 
         body: JSON.stringify({
 
@@ -221,6 +223,22 @@ export default function AdminRegisterPage() {
           onChange={setConfirmPassword}
 
           autoComplete="new-password"
+
+        />
+
+        <AuthField
+
+          id="register-invite"
+
+          label="Invite code"
+
+          type="password"
+
+          value={inviteCode}
+
+          onChange={setInviteCode}
+
+          autoComplete="off"
 
         />
 

--- a/src/app/api/admin/auth/register/route.ts
+++ b/src/app/api/admin/auth/register/route.ts
@@ -2,11 +2,17 @@ import { jsonError, jsonOk } from "@/lib/api/http";
 import { buildAdminUserMetadata } from "@/lib/auth/admin-user-metadata";
 import { formatAuthError } from "@/lib/auth/format-auth-error";
 import { checkPassword } from "@/lib/auth/password";
+import { timingSafeStringEqual } from "@/lib/auth/timing-safe-equal";
 import { getSupabaseAdminClient, hasSupabaseAdminConfig } from "@/lib/supabase/server";
 import { adminRegisterSchema } from "@/lib/validations/admin-auth";
 
 /**
- * Creates a confirmed admin user via the service role (no manual role assignment in Supabase).
+ * Creates a confirmed admin user via the service role.
+ *
+ * @remarks
+ * Because a successful call grants full admin/CMS access, the request must carry a valid
+ * invite secret in the `x-admin-invite` header matching `ADMIN_REGISTRATION_SECRET`. The
+ * route fails closed: if no secret is configured on the server, registration is refused.
  */
 export async function POST(request: Request) {
   if (!hasSupabaseAdminConfig()) {
@@ -15,6 +21,19 @@ export async function POST(request: Request) {
       503,
       "CONFIG_ERROR",
     );
+  }
+
+  // Gate: only callers holding the invite secret may create admin accounts.
+  const registrationSecret = process.env.ADMIN_REGISTRATION_SECRET;
+  if (!registrationSecret) {
+    return jsonError(
+      "Admin registration is disabled. Set ADMIN_REGISTRATION_SECRET on the server to enable it.",
+      503,
+      "CONFIG_ERROR",
+    );
+  }
+  if (!timingSafeStringEqual(request.headers.get("x-admin-invite"), registrationSecret)) {
+    return jsonError("Invalid or missing admin invite secret", 401, "UNAUTHORIZED");
   }
 
   let body: unknown;

--- a/src/app/api/admin/content/[key]/route.ts
+++ b/src/app/api/admin/content/[key]/route.ts
@@ -26,8 +26,8 @@ export async function GET(request: Request, ctx: Params) {
     const row = await fetchSiteContent(key);
     return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to load content";
-    return jsonError(message, 500, "CONTENT_ERROR");
+    console.error("GET /api/admin/content/[key] failed:", e);
+    return jsonError("Failed to load content", 500, "CONTENT_ERROR");
   }
 }
 
@@ -63,7 +63,7 @@ export async function PUT(request: Request, ctx: Params) {
     revalidateSiteContent(key);
     return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to save content";
-    return jsonError(message, 500, "CONTENT_ERROR");
+    console.error("PUT /api/admin/content/[key] failed:", e);
+    return jsonError("Failed to save content", 500, "CONTENT_ERROR");
   }
 }

--- a/src/app/api/admin/content/upload/route.ts
+++ b/src/app/api/admin/content/upload/route.ts
@@ -49,13 +49,14 @@ export async function POST(request: Request) {
       .from(bucket)
       .upload(filePath, bytes, { contentType: file.type, upsert: false });
     if (uploadError) {
-      return jsonError(uploadError.message, 500, "UPLOAD_ERROR");
+      console.error("POST /api/admin/content/upload storage error:", uploadError);
+      return jsonError("Failed to upload image", 500, "UPLOAD_ERROR");
     }
 
     const { data } = supabase.storage.from(bucket).getPublicUrl(filePath);
     return jsonOk({ url: data.publicUrl, path: filePath, bucket });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to upload image";
-    return jsonError(message, 500, "UPLOAD_ERROR");
+    console.error("POST /api/admin/content/upload failed:", e);
+    return jsonError("Failed to upload image", 500, "UPLOAD_ERROR");
   }
 }

--- a/src/app/api/admin/listings/[id]/route.ts
+++ b/src/app/api/admin/listings/[id]/route.ts
@@ -86,8 +86,8 @@ export async function PUT(request: Request, ctx: Params) {
     }
     return jsonOk({ listing: data });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to update listing";
-    return jsonError(message, 500, "LISTINGS_ERROR");
+    console.error("PUT /api/admin/listings/[id] failed:", e);
+    return jsonError("Failed to update listing", 500, "LISTINGS_ERROR");
   }
 }
 
@@ -123,7 +123,7 @@ export async function DELETE(request: Request, ctx: Params) {
     }
     return jsonOk({ deleted: true, id });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to delete listing";
-    return jsonError(message, 500, "LISTINGS_ERROR");
+    console.error("DELETE /api/admin/listings/[id] failed:", e);
+    return jsonError("Failed to delete listing", 500, "LISTINGS_ERROR");
   }
 }

--- a/src/app/api/admin/listings/[id]/route.ts
+++ b/src/app/api/admin/listings/[id]/route.ts
@@ -1,3 +1,5 @@
+import { revalidatePath } from "next/cache";
+
 import { jsonError, jsonOk } from "@/lib/api/http";
 import { requireAdmin } from "@/lib/auth/admin";
 import {
@@ -84,6 +86,9 @@ export async function PUT(request: Request, ctx: Params) {
     if (!data) {
       return jsonError("Listing not found", 404, "NOT_FOUND");
     }
+    // Refresh the cached detail page and index after edits.
+    revalidatePath(`/listings/${id}`);
+    revalidatePath("/listings");
     return jsonOk({ listing: data });
   } catch (e) {
     console.error("PUT /api/admin/listings/[id] failed:", e);
@@ -121,6 +126,9 @@ export async function DELETE(request: Request, ctx: Params) {
     if (!ok) {
       return jsonError("Listing not found", 404, "NOT_FOUND");
     }
+    // Drop the deleted listing from the cached detail page and index.
+    revalidatePath(`/listings/${id}`);
+    revalidatePath("/listings");
     return jsonOk({ deleted: true, id });
   } catch (e) {
     console.error("DELETE /api/admin/listings/[id] failed:", e);

--- a/src/app/api/admin/listings/categories/route.ts
+++ b/src/app/api/admin/listings/categories/route.ts
@@ -42,7 +42,7 @@ export async function PUT(request: Request) {
     revalidatePath("/listings/[id]", "page");
     return jsonOk({ categories });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to save categories";
-    return jsonError(message, 500, "CATEGORIES_ERROR");
+    console.error("PUT /api/admin/listings/categories failed:", e);
+    return jsonError("Failed to save categories", 500, "CATEGORIES_ERROR");
   }
 }

--- a/src/app/api/admin/listings/route.ts
+++ b/src/app/api/admin/listings/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
     const data = await createAdminListing(row);
     return jsonOk({ listing: data }, { status: 201 });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to create listing";
-    return jsonError(message, 500, "LISTINGS_ERROR");
+    console.error("POST /api/admin/listings failed:", e);
+    return jsonError("Failed to create listing", 500, "LISTINGS_ERROR");
   }
 }

--- a/src/app/api/admin/listings/route.ts
+++ b/src/app/api/admin/listings/route.ts
@@ -1,3 +1,5 @@
+import { revalidatePath } from "next/cache";
+
 import { jsonError, jsonOk } from "@/lib/api/http";
 import { requireAdmin } from "@/lib/auth/admin";
 import { createAdminListing } from "@/lib/listings/admin";
@@ -43,6 +45,8 @@ export async function POST(request: Request) {
   const row = toListingInsert(auth.user.id, input);
   try {
     const data = await createAdminListing(row);
+    // New listing appears in the (cached) index and sitemap.
+    revalidatePath("/listings");
     return jsonOk({ listing: data }, { status: 201 });
   } catch (e) {
     console.error("POST /api/admin/listings failed:", e);

--- a/src/app/api/admin/listings/upload/route.ts
+++ b/src/app/api/admin/listings/upload/route.ts
@@ -44,13 +44,14 @@ export async function POST(request: Request) {
       .from(bucket)
       .upload(filePath, bytes, { contentType: file.type, upsert: false });
     if (uploadError) {
-      return jsonError(uploadError.message, 500, "UPLOAD_ERROR");
+      console.error("POST /api/admin/listings/upload storage error:", uploadError);
+      return jsonError("Failed to upload image", 500, "UPLOAD_ERROR");
     }
 
     const { data } = supabase.storage.from(bucket).getPublicUrl(filePath);
     return jsonOk({ url: data.publicUrl, path: filePath, bucket });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to upload image";
-    return jsonError(message, 500, "UPLOAD_ERROR");
+    console.error("POST /api/admin/listings/upload failed:", e);
+    return jsonError("Failed to upload image", 500, "UPLOAD_ERROR");
   }
 }

--- a/src/app/api/content/[key]/route.ts
+++ b/src/app/api/content/[key]/route.ts
@@ -17,7 +17,7 @@ export async function GET(_request: Request, ctx: Params) {
     const row = await fetchSiteContent(key);
     return jsonOk({ content: row.payload, updatedAt: row.updatedAt });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to load content";
-    return jsonError(message, 500, "CONTENT_ERROR");
+    console.error("GET /api/content/[key] failed:", e);
+    return jsonError("Failed to load content", 500, "CONTENT_ERROR");
   }
 }

--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
       },
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to load listings";
-    return jsonError(message, 500, "LISTINGS_ERROR");
+    console.error("GET /api/listings failed:", e);
+    return jsonError("Failed to load listings", 500, "LISTINGS_ERROR");
   }
 }

--- a/src/app/api/listings/sold/route.ts
+++ b/src/app/api/listings/sold/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
       },
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to load sold listings";
-    return jsonError(message, 500, "LISTINGS_ERROR");
+    console.error("GET /api/listings/sold failed:", e);
+    return jsonError("Failed to load sold listings", 500, "LISTINGS_ERROR");
   }
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,7 +5,14 @@ import { fetchSiteContent } from "@/lib/content/query";
 
 export const metadata: Metadata = {
   title: "Contact",
-  description: "Get in touch with Brad Enns.",
+  description: "Get in touch with Brad Enns for buying, selling, or a home valuation in Kitchener–Waterloo.",
+  alternates: { canonical: "/contact" },
+  openGraph: {
+    title: "Contact | Brad Enns",
+    description:
+      "Get in touch with Brad Enns for buying, selling, or a home valuation in Kitchener–Waterloo.",
+    url: "/contact",
+  },
 };
 
 export const dynamic = "force-dynamic";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,15 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SiteChrome } from "@/components/site-chrome";
 import { SiteFooter } from "@/components/site-footer";
+import { JsonLd } from "@/components/seo/json-ld";
+import {
+  AGENT_NAME,
+  AREAS_SERVED,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+  absoluteUrl,
+} from "@/lib/site-config";
 import "./globals.css";
 
 export const viewport: Viewport = {
@@ -23,12 +32,51 @@ const geistMono = Geist_Mono({
 
 /** Default document metadata; nested routes can export their own `metadata` objects. */
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
     default: "Brad Enns | Kitchener–Waterloo Real Estate",
     template: "%s | Brad Enns",
   },
-  description:
-    "Real estate services for buying, selling, and appraisals in Kitchener–Waterloo and surrounding communities.",
+  description: SITE_DESCRIPTION,
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    title: "Brad Enns | Kitchener–Waterloo Real Estate",
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    locale: "en_CA",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Brad Enns | Kitchener–Waterloo Real Estate",
+    description: SITE_DESCRIPTION,
+  },
+};
+
+/**
+ * Site-wide organization/agent structured data. Nested pages add more specific
+ * types (e.g. `RealEstateListing`, `Review`) that reference this same `@id`.
+ */
+const agentJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "RealEstateAgent",
+  "@id": absoluteUrl("/#agent"),
+  name: AGENT_NAME,
+  url: SITE_URL,
+  description: SITE_DESCRIPTION,
+  areaServed: AREAS_SERVED.map((name) => ({
+    "@type": "City",
+    name,
+  })),
+  knowsAbout: ["Residential real estate", "Home buying", "Home selling", "Property appraisals"],
+  address: {
+    "@type": "PostalAddress",
+    addressRegion: "ON",
+    addressCountry: "CA",
+  },
 };
 
 /**
@@ -45,6 +93,7 @@ export default async function RootLayout({
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="flex min-h-full flex-col">
+        <JsonLd data={agentJsonLd} />
         <SiteChrome footer={<SiteFooter />}>{children}</SiteChrome>
       </body>
     </html>

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -1,15 +1,94 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { ListingDetailView } from "@/components/listings/listing-detail-view";
+import { JsonLd, type JsonLdData } from "@/components/seo/json-ld";
 import {
   fetchListings,
   fetchPostalCentroids,
   fetchPublicListingById,
 } from "@/lib/listings/query";
+import type { ListingRow } from "@/lib/store/types";
+import { absoluteUrl } from "@/lib/site-config";
 import { getShowNearbyListings } from "@/lib/settings/nearby-listings";
 import { getListingCategories } from "@/lib/listings/listing-categories-store";
 
 type Params = { params: Promise<{ id: string }> };
+
+// Cache each listing page and refresh hourly; admin create/update/delete revalidate this path
+// on demand so edits appear immediately.
+export const revalidate = 3600;
+
+/** Absolute image URLs for a listing (featured first), for OG tags and structured data. */
+function listingImageUrls(listing: Pick<ListingRow, "featured_image_url" | "images">): string[] {
+  const urls = [listing.featured_image_url, ...(listing.images ?? [])].filter(
+    (url): url is string => Boolean(url),
+  );
+  return Array.from(new Set(urls));
+}
+
+/** Build `RealEstateListing` + `BreadcrumbList` structured data for a listing. */
+function buildListingJsonLd(listing: ListingRow): JsonLdData[] {
+  const url = absoluteUrl(`/listings/${listing.id}`);
+  const images = listingImageUrls(listing);
+
+  const realEstateListing: JsonLdData = {
+    "@context": "https://schema.org",
+    "@type": "RealEstateListing",
+    "@id": url,
+    url,
+    name: listing.title,
+    description: buildDescription(listing),
+    ...(images.length > 0 ? { image: images } : {}),
+    ...(listing.status === "sold" ? { availability: "https://schema.org/SoldOut" } : {}),
+    ...(listing.price_dollars !== null
+      ? {
+          offers: {
+            "@type": "Offer",
+            price: listing.price_dollars,
+            priceCurrency: "CAD",
+            availability:
+              listing.status === "sold"
+                ? "https://schema.org/SoldOut"
+                : "https://schema.org/InStock",
+          },
+        }
+      : {}),
+    ...(listing.address_line || listing.city
+      ? {
+          address: {
+            "@type": "PostalAddress",
+            ...(listing.address_line ? { streetAddress: listing.address_line } : {}),
+            ...(listing.city ? { addressLocality: listing.city } : {}),
+            ...(listing.province ? { addressRegion: listing.province } : {}),
+            ...(listing.postal_code ? { postalCode: listing.postal_code } : {}),
+            addressCountry: "CA",
+          },
+        }
+      : {}),
+    ...(listing.latitude !== null && listing.longitude !== null
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: listing.latitude,
+            longitude: listing.longitude,
+          },
+        }
+      : {}),
+    broker: { "@id": absoluteUrl("/#agent") },
+  };
+
+  const breadcrumb: JsonLdData = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: absoluteUrl("/") },
+      { "@type": "ListItem", position: 2, name: "Listings", item: absoluteUrl("/listings") },
+      { "@type": "ListItem", position: 3, name: listing.title, item: url },
+    ],
+  };
+
+  return [realEstateListing, breadcrumb];
+}
 
 function buildDescription(listing: {
   subtitle: string | null;
@@ -32,13 +111,26 @@ export async function generateMetadata(ctx: Params): Promise<Metadata> {
       description: "This listing is not available.",
     };
   }
+  const canonical = `/listings/${id}`;
+  const images = listingImageUrls(listing);
   return {
     title: `${listing.title} | Listings`,
     description: buildDescription(listing),
+    alternates: { canonical },
     openGraph: {
+      type: "website",
       title: listing.title,
       description: buildDescription(listing),
-      images: [listing.featured_image_url || listing.images[0] || "https://placehold.co/1200x700/png?text=Listing"],
+      url: canonical,
+      images: [
+        images[0] || "https://placehold.co/1200x700/png?text=Listing",
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: listing.title,
+      description: buildDescription(listing),
+      images: [images[0] || "https://placehold.co/1200x700/png?text=Listing"],
     },
   };
 }
@@ -89,8 +181,15 @@ export default async function ListingDetailPage(ctx: Params) {
     getListingCategories(),
   ]);
 
+  const listingJsonLd = buildListingJsonLd(listing);
+
   if (!showNearby) {
-    return <ListingDetailView listing={listing} nearby={[]} categories={categories} />;
+    return (
+      <>
+        <JsonLd data={listingJsonLd} />
+        <ListingDetailView listing={listing} nearby={[]} categories={categories} />
+      </>
+    );
   }
 
   const { items } = await fetchListings(listing.status === "sold" ? "sold" : "active", {
@@ -129,5 +228,10 @@ export default async function ListingDetailPage(ctx: Params) {
     .slice(0, 5)
     .map((entry) => entry.item);
 
-  return <ListingDetailView listing={listing} nearby={nearby} categories={categories} />;
+  return (
+    <>
+      <JsonLd data={listingJsonLd} />
+      <ListingDetailView listing={listing} nearby={nearby} categories={categories} />
+    </>
+  );
 }

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -183,50 +183,44 @@ export default async function ListingDetailPage(ctx: Params) {
 
   const listingJsonLd = buildListingJsonLd(listing);
 
-  if (!showNearby) {
-    return (
-      <>
-        <JsonLd data={listingJsonLd} />
-        <ListingDetailView listing={listing} nearby={[]} categories={categories} />
-      </>
+  let nearby: Awaited<ReturnType<typeof fetchListings>>["items"] = [];
+  if (showNearby) {
+    const { items } = await fetchListings(listing.status === "sold" ? "sold" : "active", {
+      page: 1,
+      limit: 100,
+    });
+
+    const candidates = items.filter((item) => item.id !== listing.id);
+    const sourcePrefix = postalPrefix(listing.postal_code);
+    const candidatePrefixes = candidates
+      .map((item) => postalPrefix(item.postal_code))
+      .filter((p): p is string => Boolean(p));
+    const centroidMap = await fetchPostalCentroids(
+      sourcePrefix ? [sourcePrefix, ...candidatePrefixes] : candidatePrefixes,
     );
+
+    const sourceCentroid = sourcePrefix ? centroidMap[sourcePrefix] : undefined;
+    const sourceCoords = hasCoords(listing)
+      ? { latitude: listing.latitude, longitude: listing.longitude }
+      : sourceCentroid;
+
+    nearby = candidates
+      .map((item) => {
+        const itemCoords = hasCoords(item)
+          ? { latitude: item.latitude, longitude: item.longitude }
+          : undefined;
+        const p = postalPrefix(item.postal_code);
+        const c = p ? centroidMap[p] : undefined;
+        const destinationCoords = itemCoords ?? c;
+        if (!sourceCoords || !destinationCoords) {
+          return { item, distanceKm: Number.POSITIVE_INFINITY };
+        }
+        return { item, distanceKm: haversineKm(sourceCoords, destinationCoords) };
+      })
+      .sort((a, b) => a.distanceKm - b.distanceKm)
+      .slice(0, 5)
+      .map((entry) => entry.item);
   }
-
-  const { items } = await fetchListings(listing.status === "sold" ? "sold" : "active", {
-    page: 1,
-    limit: 100,
-  });
-
-  const candidates = items.filter((item) => item.id !== listing.id);
-  const sourcePrefix = postalPrefix(listing.postal_code);
-  const candidatePrefixes = candidates
-    .map((item) => postalPrefix(item.postal_code))
-    .filter((p): p is string => Boolean(p));
-  const centroidMap = await fetchPostalCentroids(
-    sourcePrefix ? [sourcePrefix, ...candidatePrefixes] : candidatePrefixes,
-  );
-
-  const sourceCentroid = sourcePrefix ? centroidMap[sourcePrefix] : undefined;
-  const sourceCoords = hasCoords(listing)
-    ? { latitude: listing.latitude, longitude: listing.longitude }
-    : sourceCentroid;
-
-  const nearby = candidates
-    .map((item) => {
-      const itemCoords = hasCoords(item)
-        ? { latitude: item.latitude, longitude: item.longitude }
-        : undefined;
-      const p = postalPrefix(item.postal_code);
-      const c = p ? centroidMap[p] : undefined;
-      const destinationCoords = itemCoords ?? c;
-      if (!sourceCoords || !destinationCoords) {
-        return { item, distanceKm: Number.POSITIVE_INFINITY };
-      }
-      return { item, distanceKm: haversineKm(sourceCoords, destinationCoords) };
-    })
-    .sort((a, b) => a.distanceKm - b.distanceKm)
-    .slice(0, 5)
-    .map((entry) => entry.item);
 
   return (
     <>

--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -11,10 +11,20 @@ const poppins = Poppins({
 
 export const metadata: Metadata = {
   title: "Listings",
-  description: "Active and sold property listings.",
+  description:
+    "Browse active and recently sold homes for sale in Kitchener–Waterloo and surrounding communities.",
+  alternates: { canonical: "/listings" },
+  openGraph: {
+    title: "Listings | Brad Enns",
+    description:
+      "Browse active and recently sold homes for sale in Kitchener–Waterloo and surrounding communities.",
+    url: "/listings",
+  },
 };
 
-export const dynamic = "force-dynamic";
+// Listings render live via a client-side fetch; the server shell can be cached and refreshed
+// on demand (the categories admin route revalidates this path).
+export const revalidate = 3600;
 
 /**
  * Marketing listings index matching design layout (category strip + grid).

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/site-config";
+
+/** `GET /robots.txt` — allow crawling of public pages, block admin and API surfaces. */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin", "/api"],
+    },
+    sitemap: absoluteUrl("/sitemap.xml"),
+    host: absoluteUrl("/"),
+  };
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -12,6 +12,12 @@ const poppins = Poppins({
 export const metadata: Metadata = {
   title: "Services",
   description: "Enns Real Estate services in Kitchener–Waterloo and surrounding communities.",
+  alternates: { canonical: "/services" },
+  openGraph: {
+    title: "Services | Brad Enns",
+    description: "Enns Real Estate services in Kitchener–Waterloo and surrounding communities.",
+    url: "/services",
+  },
 };
 
 export const dynamic = "force-dynamic";

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+import { fetchListings } from "@/lib/listings/query";
+import { absoluteUrl } from "@/lib/site-config";
+
+/** Refresh the sitemap hourly so newly published/sold listings appear without a redeploy. */
+export const revalidate = 3600;
+
+/** `GET /sitemap.xml` — static marketing routes plus every public (active + sold) listing. */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticEntries: MetadataRoute.Sitemap = [
+    { url: absoluteUrl("/"), changeFrequency: "weekly", priority: 1 },
+    { url: absoluteUrl("/listings"), changeFrequency: "daily", priority: 0.9 },
+    { url: absoluteUrl("/about"), changeFrequency: "monthly", priority: 0.7 },
+    { url: absoluteUrl("/services"), changeFrequency: "monthly", priority: 0.7 },
+    { url: absoluteUrl("/contact"), changeFrequency: "yearly", priority: 0.6 },
+  ];
+
+  let listingEntries: MetadataRoute.Sitemap = [];
+  try {
+    const [active, sold] = await Promise.all([
+      fetchListings("active", { page: 1, limit: 1000 }),
+      fetchListings("sold", { page: 1, limit: 1000 }),
+    ]);
+    listingEntries = [...active.items, ...sold.items].map((listing) => ({
+      url: absoluteUrl(`/listings/${listing.id}`),
+      lastModified: listing.updated_at ? new Date(listing.updated_at) : undefined,
+      changeFrequency: "weekly",
+      priority: listing.status === "sold" ? 0.5 : 0.8,
+    }));
+  } catch {
+    // If listings can't be loaded, still return the static routes rather than failing the sitemap.
+    listingEntries = [];
+  }
+
+  return [...staticEntries, ...listingEntries];
+}

--- a/src/components/admin/listings-editor/components/editor-photos-panel.tsx
+++ b/src/components/admin/listings-editor/components/editor-photos-panel.tsx
@@ -124,9 +124,13 @@ export function EditorPhotosPanel({
 
   const photoOrderKey = photos.map((p) => photoKey(p)).join("|");
 
-  useEffect(() => {
+  // Reset the hero preview to the first photo whenever the photo set/order changes.
+  // Done during render (React's recommended alternative to a setState-in-effect).
+  const [prevPhotoOrderKey, setPrevPhotoOrderKey] = useState(photoOrderKey);
+  if (photoOrderKey !== prevPhotoOrderKey) {
+    setPrevPhotoOrderKey(photoOrderKey);
     setPreviewIndex(0);
-  }, [photoOrderKey]);
+  }
 
   useEffect(() => {
     if (!previewSrc && !showAllPhotos) {
@@ -167,7 +171,7 @@ export function EditorPhotosPanel({
     }
   }
 
-  function PhotoHoverActions({ photo, isMain }: { photo: EditorPhotoItem; isMain: boolean }) {
+  function renderPhotoHoverActions({ photo, isMain }: { photo: EditorPhotoItem; isMain: boolean }) {
     const position = photos.findIndex((p) => photoKey(p) === photoKey(photo));
     const canMoveEarlier = position > 0;
     const canMoveLater = position >= 0 && position < photos.length - 1;
@@ -223,7 +227,7 @@ export function EditorPhotosPanel({
     );
   }
 
-  function MainStarButton({
+  function renderMainStarButton({
     photo,
     photoIndex,
     className = "",
@@ -283,9 +287,9 @@ export function EditorPhotosPanel({
               Main
             </span>
           ) : null}
-          {previewPhoto ? (
-            <PhotoHoverActions photo={previewPhoto} isMain={safePreviewIndex === 0} />
-          ) : null}
+          {previewPhoto
+            ? renderPhotoHoverActions({ photo: previewPhoto, isMain: safePreviewIndex === 0 })
+            : null}
         </div>
 
         <div className="grid grid-cols-2 grid-rows-2 gap-3 md:h-[280px]">
@@ -348,7 +352,7 @@ export function EditorPhotosPanel({
                   className="object-cover"
                   unoptimized={photo!.kind === "existing"}
                 />
-                <PhotoHoverActions photo={photo!} isMain={thumbIndex === 0} />
+                {renderPhotoHoverActions({ photo: photo!, isMain: thumbIndex === 0 })}
               </div>
             );
           })}
@@ -424,7 +428,7 @@ export function EditorPhotosPanel({
                     className="object-cover"
                     unoptimized={photo.kind === "existing"}
                   />
-                  <MainStarButton photo={photo} photoIndex={photoIndex} />
+                  {renderMainStarButton({ photo, photoIndex })}
                   <div className="absolute inset-0 z-[5] flex flex-wrap items-center justify-center gap-2 bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
                     {photoIndex > 0 ? (
                       <button

--- a/src/components/admin/reviews-manager.tsx
+++ b/src/components/admin/reviews-manager.tsx
@@ -9,7 +9,6 @@ import {
   adminInputClass,
   adminLinkClass,
   adminPrimaryButtonClass,
-  adminSecondaryButtonClass,
   adminTextareaClass,
   AdminPageHeader,
 } from "@/components/admin/admin-ui";

--- a/src/components/home/home-hero.tsx
+++ b/src/components/home/home-hero.tsx
@@ -27,7 +27,7 @@ export function HomeHero({
     <section className="relative min-h-[calc(100dvh-var(--site-header-offset))] w-full overflow-hidden">
       <Image
         src={heroImageUrl || FALLBACK_HERO_IMAGE}
-        alt=""
+        alt="Kitchener–Waterloo homes and neighbourhoods served by Brad Enns Real Estate"
         fill
         priority
         sizes="100vw"

--- a/src/components/seo/json-ld.tsx
+++ b/src/components/seo/json-ld.tsx
@@ -1,0 +1,18 @@
+/** A JSON-LD structured-data object (a `@context`/`@type` graph node). */
+export type JsonLdData = Record<string, unknown>;
+
+/**
+ * Renders a JSON-LD `<script>` for structured data. Safe to render in server components.
+ *
+ * @remarks
+ * Content is JSON-serialized (not executable JS); the site CSP already permits
+ * `script-src 'self' 'unsafe-inline'`, which covers `application/ld+json` blocks.
+ */
+export function JsonLd({ data }: { data: JsonLdData | JsonLdData[] }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -1,5 +1,6 @@
 import { isAdminAuthBypassEnabled } from "@/lib/auth/admin-bypass";
 import { isAdminJwtUser } from "@/lib/auth/roles";
+import { timingSafeStringEqual } from "@/lib/auth/timing-safe-equal";
 import { getSupabaseAdminClient, hasSupabaseAdminConfig } from "@/lib/supabase/server";
 
 /** Admin identity returned when Supabase-backed admin auth succeeds. */
@@ -58,7 +59,7 @@ export async function requireAdmin(request: Request): Promise<AdminAuthResult> {
     if (!token) {
       return { ok: false, status: 401, message: "Missing Bearer token" };
     }
-    if (token !== staticAdminToken) {
+    if (!timingSafeStringEqual(token, staticAdminToken)) {
       return { ok: false, status: 401, message: "Invalid admin token" };
     }
     return { ok: true, user: { id: "static-admin", email: "admin@local" } };

--- a/src/lib/auth/timing-safe-equal.ts
+++ b/src/lib/auth/timing-safe-equal.ts
@@ -1,0 +1,23 @@
+import { timingSafeEqual } from "crypto";
+
+/**
+ * Constant-time string comparison for secrets (tokens, invite codes).
+ *
+ * Avoids leaking length/content via early-exit timing the way `===`/`!==` can.
+ * Returns `false` for any null/undefined input and never throws on length mismatch.
+ *
+ * @param a - First value (e.g. the value supplied by the caller).
+ * @param b - Second value (e.g. the configured secret).
+ * @returns `true` only when both are non-empty strings of equal bytes.
+ */
+export function timingSafeStringEqual(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}

--- a/src/lib/content/revalidate.ts
+++ b/src/lib/content/revalidate.ts
@@ -1,7 +1,6 @@
 import { revalidatePath } from "next/cache";
 
-import type { SiteContentKey } from "@/lib/content/keys";
-import { SITE_CONTENT_PAGES } from "@/lib/content/keys";
+import { SITE_CONTENT_PAGES, type SiteContentKey } from "@/lib/content/keys";
 
 const MARKETING_PATHS = ["/", "/about", "/services", "/contact"] as const;
 

--- a/src/lib/listings/query.ts
+++ b/src/lib/listings/query.ts
@@ -30,10 +30,19 @@ export type ListQuery = z.infer<typeof listQuerySchema>;
  * @param query - Pagination and filter options (validated with {@link listQuerySchema}).
  * @returns `items` for the requested page and `total` count after filters (before pagination).
  */
+/**
+ * Reduces a user search term to characters safe to interpolate into a PostgREST
+ * `ilike`/`.or()` filter string.
+ *
+ * Uses an allowlist (letters incl. accented, digits, spaces, hyphen, apostrophe) rather than a
+ * denylist: PostgREST filter grammar treats `. , ( ) *` and the `ilike` wildcards `% _` as
+ * structural, so any of them reaching the builder could distort the OR expression. Collapses
+ * runs of whitespace and trims.
+ */
 function sanitizeSearchLike(value: string) {
   return value
-    .replace(/[%_\\]/g, "")
-    .replace(/,/g, " ")
+    .replace(/[^\p{L}\p{N}\s'-]/gu, " ")
+    .replace(/\s+/g, " ")
     .trim();
 }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,3 +1,7 @@
+// TODO(security): This is a per-process, in-memory limiter. On serverless/edge (Vercel) the
+// state is NOT shared across instances and resets on redeploy, so it is best-effort only.
+// For production, back this with a shared store (Upstash Redis / Vercel KV) and extend it to
+// the admin registration and upload routes. See docs/security-audit.md (finding 7).
 type Bucket = { count: number; resetAt: number };
 
 const buckets = new Map<string, Bucket>();

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,0 +1,61 @@
+/**
+ * Canonical site identity used for SEO: `metadataBase`, canonical URLs, the sitemap,
+ * robots, Open Graph image resolution, and JSON-LD structured data.
+ */
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function withProtocol(value: string): string {
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}
+
+/**
+ * Resolves the canonical site origin (scheme + host, no trailing slash).
+ *
+ * Resolution order:
+ * 1. `NEXT_PUBLIC_SITE_URL` — set this to the production domain (e.g. `https://www.example.com`).
+ *    This is the value to configure in production; everything else is a fallback.
+ * 2. `VERCEL_PROJECT_PRODUCTION_URL` — Vercel's production domain, used automatically on deploys
+ *    when the explicit var is not set.
+ * 3. `http://localhost:3000` — local development default.
+ */
+function resolveSiteUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (explicit) {
+    return stripTrailingSlash(withProtocol(explicit));
+  }
+  const vercel = process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim();
+  if (vercel) {
+    return `https://${stripTrailingSlash(vercel)}`;
+  }
+  return "http://localhost:3000";
+}
+
+/** Canonical site origin, e.g. `https://www.example.com` (no trailing slash). */
+export const SITE_URL = resolveSiteUrl();
+
+/** Absolute URL for a site-relative path, e.g. `absoluteUrl("/listings")`. */
+export function absoluteUrl(path = "/"): string {
+  return `${SITE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+/** Human-facing site/brand name. */
+export const SITE_NAME = "Brad Enns Real Estate";
+
+/** Agent name used across metadata and structured data. */
+export const AGENT_NAME = "Brad Enns";
+
+/** One-line site description reused as an Open Graph / structured-data default. */
+export const SITE_DESCRIPTION =
+  "Real estate services for buying, selling, and appraisals in Kitchener–Waterloo and surrounding communities.";
+
+/** Communities served, used for structured data `areaServed`. */
+export const AREAS_SERVED = [
+  "Kitchener",
+  "Waterloo",
+  "Cambridge",
+  "Elmira",
+  "New Hamburg",
+] as const;


### PR DESCRIPTION
Security hardening and SEO fundamentals. **Stacked on #65** — base is `feat/listings-site-features`, so this PR shows only the security/SEO/lint/refactor commits (~927 LoC). It will auto-retarget to `main` once #65 merges.

## Security
- Gated admin registration behind `ADMIN_REGISTRATION_SECRET` (fails closed; constant-time compare)
- HTTP security headers (CSP, HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy)
- Constant-time `ADMIN_API_TOKEN` compare
- Allowlist-based search sanitization (PostgREST filter safety)
- Generic error responses across API routes (detail logged server-side)
- Documented rate-limit shared-store TODO

## SEO
- `sitemap.ts` + `robots.ts`
- `metadataBase`, per-page canonicals, site-wide Open Graph + Twitter
- JSON-LD: RealEstateAgent (org), RealEstateListing + BreadcrumbList, Review/AggregateRating
- ISR (revalidate) with on-demand `revalidatePath` on admin writes
- Descriptive alt text

## Other
- chore: fix pre-existing lint errors
- refactor(listings): dedupe listing detail render branches

See `docs/security-audit.md`, `docs/seo-audit.md`, `docs/pre-launch-todo.md` for detail and remaining human actions (secret rotation, `NEXT_PUBLIC_SITE_URL`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)